### PR TITLE
Us18 task72 API call to return sprint stats 

### DIFF
--- a/taigit/src/components/Taiga.js
+++ b/taigit/src/components/Taiga.js
@@ -3,8 +3,6 @@ import StackedBarChart from './charts/StackedBarChart';
 import stackBarChartData from './charts/stackedBarChartData';
 import DoughnutChart from './charts/DoughnutChart';
 
-
-
 let taigaUsProgress = {
   labels: ["Completed", "In Progress", "Not Done"],
   datasets: [{
@@ -29,9 +27,7 @@ export default class Taiga extends Component {
         <div className="chart chart-stacked-bar">
           <span className="chart-title">Taiga Tasks</span>
           <StackedBarChart chartData={stackBarChartData}/>
-
         </div>
-
       </div>
     );
   }

--- a/taigit/src/components/Taiga.js
+++ b/taigit/src/components/Taiga.js
@@ -3,7 +3,7 @@ import StackedBarChart from './charts/StackedBarChart';
 import stackBarChartData from './charts/stackedBarChartData';
 import DoughnutChart from './charts/DoughnutChart';
 
-import {sprint_info}  from '../libraries/Taiga'
+
 
 let taigaUsProgress = {
   labels: ["Completed", "In Progress", "Not Done"],
@@ -29,8 +29,7 @@ export default class Taiga extends Component {
         <div className="chart chart-stacked-bar">
           <span className="chart-title">Taiga Tasks</span>
           <StackedBarChart chartData={stackBarChartData}/>
-            {console.log(sprint_info(219984).then((val) => {console.log('fe', val)} ))}
-            ))}
+
         </div>
 
       </div>

--- a/taigit/src/components/Taiga.js
+++ b/taigit/src/components/Taiga.js
@@ -3,6 +3,8 @@ import StackedBarChart from './charts/StackedBarChart';
 import stackBarChartData from './charts/stackedBarChartData';
 import DoughnutChart from './charts/DoughnutChart';
 
+import {sprint_info}  from '../libraries/Taiga'
+
 let taigaUsProgress = {
   labels: ["Completed", "In Progress", "Not Done"],
   datasets: [{
@@ -27,7 +29,10 @@ export default class Taiga extends Component {
         <div className="chart chart-stacked-bar">
           <span className="chart-title">Taiga Tasks</span>
           <StackedBarChart chartData={stackBarChartData}/>
+            {console.log(sprint_info(219984).then((val) => {console.log('fe', val)} ))}
+            ))}
         </div>
+
       </div>
     );
   }

--- a/taigit/src/libraries/Taiga.ts
+++ b/taigit/src/libraries/Taiga.ts
@@ -27,3 +27,10 @@ project_stats(projId : number) : Promise<Object> {
     
     return (data.data);
 }
+
+//This call returns sprint stats based on sprintId
+export async function
+sprint_info(sprintId : number) : Promise<Object> {
+    let data = await axios.get("https://api.taiga.io/api/v1/milestones/"+sprintId.toString()+ '/stats');
+     return (data.data);
+}

--- a/taigit/src/libraries/Taiga.ts
+++ b/taigit/src/libraries/Taiga.ts
@@ -30,7 +30,7 @@ project_stats(projId : number) : Promise<Object> {
 
 //This call returns sprint stats based on sprintId
 export async function
-sprint_info(sprintId : number) : Promise<Object> {
+sprint_stats(sprintId : number) : Promise<Object> {
     let data = await axios.get("https://api.taiga.io/api/v1/milestones/"+sprintId.toString()+ '/stats');
      return (data.data);
 }


### PR DESCRIPTION
API call returns sprint stats based on sprintId

To test add this line (and import sprint_stats) to any one of the front end .js files in the project and view the output in the console window
Test Script:
            {console.log(sprint_stats(219984).then((val) => {console.log('fe', val)} ))}
            ))}
Expected Result:
fe {name: "Sprint 1 - Backend", estimated_start: "2019-02-16", estimated_finish: "2019-02-22", total_points: {…}, completed_points: Array(1), …}