### PR TITLE
API to return User List and Task details for each user in each sprint 

### DIFF
--- a/taigit/src/libraries/Taiga.ts
+++ b/taigit/src/libraries/Taiga.ts
@@ -1,4 +1,6 @@
-import axios from "axios"
+import axios from "axios";
+import request from "request";
+import { callbackify } from "util";
 
 export async function
 taiga_login(username : string, password : string) : Promise<boolean> {
@@ -7,7 +9,7 @@ taiga_login(username : string, password : string) : Promise<boolean> {
         "type": "normal",
         "username": username
     })
-
+    
     return (response.status == 200);
 }
 
@@ -26,4 +28,145 @@ project_stats(projId : number) : Promise<Object> {
     let data = await axios.get("https://api.taiga.io/api/v1/projects/" + projId.toString() + '/stats');
     
     return (data.data);
+}
+
+// This returns an array of member's full name in a project 
+export async function
+getUserList(projName: string, callB:(body: any, membersInProject: any) => any) {
+    let options: any = {
+        headers: { 
+            'Content-Type': 'application/json',
+        },
+        json: true
+    }
+    request.get('https://api.taiga.io/api/v1/projects/by_slug?slug=' + projName, options, (error:any, response: any, body:any) => {
+        let content:any;
+        let membersInProject = [];
+        for (content of body.members) {
+            membersInProject.push(content.full_name);
+        }
+        callB(body, membersInProject);
+    });
+
+}
+
+/* This function returns an Array for each member with below details:
+inProgressTaskCount: 3
+name: "Cecilia La Place"
+newTaskCount: 1
+sprintName: "Sprint 2 - Taiga"
+taskReadyForTestCount: 0
+taskWithUnknownStatusCount: 0
+totalTaskCount: 4
+*/
+export async function
+getMileStoneIds(respForFutureExtraction:any, callB:(taskCountDetails:any) => any) {
+    let sprintDetailsArray: any;
+    sprintDetailsArray = respForFutureExtraction.milestones;
+    let sprintDetail:any;
+    
+    for (sprintDetail of sprintDetailsArray) {
+        getSprintIds(sprintDetail, ( projectId: any, sprintId: any, sprintName: any) => {
+            // we need to call task details here.
+            getTaskDetails(sprintId, projectId, sprintName, (taskCountDetails:any) => {
+                callB(taskCountDetails);
+            }); 
+        });
+        
+    }
+}
+
+export async function
+getSprintIds(sprintDetail: any, callB:(projectId:any, sprintId: any, sprintName:any) => any) {
+    let sprintId:any, projectId: any, sprintName:any;
+    let options: any = {
+        headers: { 
+            'Content-Type': 'application/json',
+        },
+        json: true
+    }
+    sprintId = sprintDetail.id; 
+    sprintName = sprintDetail.name;
+            
+    request.get('https://api.taiga.io/api/v1/milestones/' + sprintId, options, (error:any, response: any, body:any) => {
+        projectId = body.project_extra_info.id;
+        callB(projectId, sprintId, sprintName);
+        
+    });
+}
+
+export async function
+getTaskDetails (sprintId: string, projectId : any, sprintName: any, callB:(taskCount:any) => any) {
+    
+    let options: any = {
+        headers: { 
+            'Content-Type': 'application/json',
+        },
+        json: true
+    }
+    let dictTaskCount:any = {};
+    let jsonObj : any = {};
+    let bigObj : any = [];
+    request.get('https://api.taiga.io/api/v1/tasks?milestone=' + sprintId + "&&project=" + projectId , options, (error:any, response: any, body:any) => {
+        for (let taskName of body) {
+            let name = taskName.owner_extra_info.full_name_display;
+            let taskStatusName = taskName.status_extra_info.name;
+            let taskStatus = taskName.status_extra_info.is_closed;
+            let nameKey:any;
+            if (name in dictTaskCount) {
+                nameKey = dictTaskCount[name];
+                dictTaskCount[name] = nameKey+1;
+                
+                for (let i = 0; i < bigObj.length; i ++ ) {
+                    if (name === bigObj[i].name) {
+                        bigObj[i].totalTaskCount = bigObj[i].totalTaskCount + 1;
+                        if (taskStatus === true) {
+                            bigObj[i].closedTaskCount = bigObj[i].closedTaskCount + 1;
+                        } else {
+                            if (taskStatusName === "Ready for test") {
+                                bigObj[i].taskReadyForTestCount = bigObj[i].taskReadyForTestCount + 1;
+                            } else if (taskStatusName === "In progress") {
+                                bigObj[i].inProgressTaskCount = bigObj[i].inProgressTaskCount + 1;
+                            } else if (taskStatusName === "New") {
+                                bigObj[i].newTaskCount = bigObj[i].newTaskCount + 1;
+                            }
+                            else {
+                                bigObj[i].taskWithUnknownStatusCount = bigObj[i].taskWithUnknownStatusCount + 1;
+                            }
+                        }
+                        
+                    }
+                }    
+            } else {
+                // This block will execute only once for 
+                // for each team member
+                dictTaskCount[name] = 1;
+                jsonObj={};
+                jsonObj['name'] = name;
+                jsonObj['sprintName'] = sprintName;
+                jsonObj['totalTaskCount'] = 1;
+                jsonObj['taskReadyForTestCount'] = 0;
+                jsonObj['inProgressTaskCount'] = 0;
+                jsonObj['newTaskCount'] = 0;
+                jsonObj['taskWithUnknownStatusCount'] = 0;
+                jsonObj['closedTaskCount'] = 0;
+                
+                if (taskStatus === true) {
+                    jsonObj['closedTaskCount'] = 1;
+                } else {
+                    if (taskStatusName === "Ready for test") {
+                        jsonObj['taskReadyForTestCount'] = 1;
+                    } else if (taskStatusName === "In progress") {
+                        jsonObj['inProgressTaskCount'] = 1;
+                    } else if (taskStatusName === "New") {
+                        jsonObj['newTaskCount'] = 1;
+                    } else {
+                        jsonObj['taskWithUnknownStatusCount'] = 1
+                    }
+                }
+                bigObj.push(jsonObj);
+            }
+        }
+        callB(bigObj);
+    });
 }


### PR DESCRIPTION
This implementation uses request and call back for async functions. This does have conflict with dev branch, I can take care of it later once the review is done.

Also, please feel free to add someone from frontend team so that they can see the format and create their chart accordingly.  

{console.log(getUserList('sanaydevi-ser-574', (respForFutureExtraction, memberList) => {
                console.log('getUserList: ', memberList);
                getMileStoneIds(respForFutureExtraction, (taskCountDetails) => {
                  console.log('taskCountDetails:: ', taskCountDetails);
                });
              }
          ))
        }

When you keep above call in a js file , it will print below details in console. The call can be as per need of the front end team.

getUserList:  (13) ["Aditya Samant", "Bijayalaxmi Panda", "Cecilia La Place", "David Lahtinen", "Debarati Bhattacharyya", "Jainish Soni", "John Alden", "Paul Horton", "Ruby Zhao", "Sanay Vinay Devi", "Trevor Forrey", "Venkata Akhil Madaraju", "Xiangwei Zheng"]
taskCountDetails::
0:
closedTaskCount: 3
inProgressTaskCount: 0
name: "Aditya Samant"
newTaskCount: 0
sprintName: "Sprint 1 - GitHub Team"
taskReadyForTestCount: 0
taskWithUnknownStatusCount: 0
totalTaskCount: 3
__proto__: Object
1:
closedTaskCount: 2
inProgressTaskCount: 1
name: "David Lahtinen"
newTaskCount: 0
sprintName: "Sprint 1 - GitHub Team"
taskReadyForTestCount: 0
taskWithUnknownStatusCount: 0
totalTaskCount: 3
__proto__: Object
2:
closedTaskCount: 1
inProgressTaskCount: 0
name: "Sanay Vinay Devi"
newTaskCount: 0
sprintName: "Sprint 1 - GitHub Team"
taskReadyForTestCount: 0
taskWithUnknownStatusCount: 0
totalTaskCount: 1
__proto__: Object
3:
closedTaskCount: 4
inProgressTaskCount: 2
name: "Paul Horton"
newTaskCount: 0
sprintName: "Sprint 1 - GitHub Team"
taskReadyForTestCount: 0
taskWithUnknownStatusCount: 0
totalTaskCount: 6
__proto__: Object
length: 4