### PR TITLE
Us18 task71 76 update API for task and user story stats

### DIFF
--- a/taigit/src/libraries/Taiga.ts
+++ b/taigit/src/libraries/Taiga.ts
@@ -39,7 +39,7 @@ sprint_stats(sprintId : number) : Promise<Object> {
 
 //This call returns user story  stats based on userstory Id
 export async function
-userstory_stats(userstoryId : number) : Promise<Object> {
+userstory_statuses(userstoryId : number) : Promise<Object> {
     let data = await axios.get("https://api.taiga.io/api/v1/userstory-statuses/"+userstoryId.toString());
     //test link:  https://api.taiga.io/api/v1/userstory-statuses/1124228
     return (data.data)
@@ -49,7 +49,7 @@ userstory_stats(userstoryId : number) : Promise<Object> {
 
 //This call returns task stats based on task Id
 export async function
-task_stats(taskId : number) : Promise<Object> {
+task_statuses(taskId : number) : Promise<Object> {
     let data = await axios.get("https://api.taiga.io/api/v1/task-statuses/" + taskId.toString());
     //test link:  https://api.taiga.io/api/v1/task-statuses/1550500
     return (data.data)

--- a/taigit/src/libraries/Taiga.ts
+++ b/taigit/src/libraries/Taiga.ts
@@ -44,3 +44,12 @@ userstory_stats(userstoryId : number) : Promise<Object> {
     //test link:  https://api.taiga.io/api/v1/userstory-statuses/1124228
     return (data.data)
 }
+
+
+
+//This call returns task stats based on task Id
+export async function
+task_stats(taskId : number) : Promise<Object> {
+    let data = await axios.get("https://api.taiga.io/api/v1/task-statuses/" + taskId.toString());
+    //test link:  https://api.taiga.io/api/v1/task-statuses/1550500
+    return (data.data)

--- a/taigit/src/libraries/Taiga.ts
+++ b/taigit/src/libraries/Taiga.ts
@@ -53,3 +53,4 @@ task_stats(taskId : number) : Promise<Object> {
     let data = await axios.get("https://api.taiga.io/api/v1/task-statuses/" + taskId.toString());
     //test link:  https://api.taiga.io/api/v1/task-statuses/1550500
     return (data.data)
+}

--- a/taigit/src/libraries/Taiga.ts
+++ b/taigit/src/libraries/Taiga.ts
@@ -34,3 +34,13 @@ sprint_stats(sprintId : number) : Promise<Object> {
     let data = await axios.get("https://api.taiga.io/api/v1/milestones/"+sprintId.toString()+ '/stats');
      return (data.data);
 }
+
+
+
+//This call returns user story  stats based on userstory Id
+export async function
+userstory_stats(userstoryId : number) : Promise<Object> {
+    let data = await axios.get("https://api.taiga.io/api/v1/userstory-statuses/"+userstoryId.toString());
+    //test link:  https://api.taiga.io/api/v1/userstory-statuses/1124228
+    return (data.data)
+}


### PR DESCRIPTION
1 userstory_stats API call  returns user story  stats based on userstory Id

To test add this line (and import userstory_stats) to any one of the front end .js files in the project and view the output in the console window
Test add-on:
import {userstory_stats}  from '../libraries/Taiga'

{console.log(userstory_stats(1124228).then((val) => {console.log('fe', val)} ))}

Expected Result:
fe {id: 1124228, name: "New", slug: "new", order: 1, is_closed: false, …}



2 task_stats API call returns task stats based on task Id

To test add this line (and import task_stats) to any one of the front end .js files in the project and view the output in the console window

Test add-on:
import {task_stats}  from '../libraries/Taiga'


{console.log(task_stats(1550500).then((val) => {console.log('fe', val)} ))}


Expected:
fe {id: 1550500, name: "New", slug: "new", order: 1, is_closed: false, …}


