### PR TITLE
US102 T119 Task History

### DIFF
--- a/taigit/src/libraries/Taiga.ts
+++ b/taigit/src/libraries/Taiga.ts
@@ -15,7 +15,7 @@ taiga_login(username : string, password : string) : Promise<boolean> {
 export async function
 project_info(slug : string) : Promise<Object> {
     let data = await axios.get("https://api.taiga.io/api/v1/projects/by_slug?slug=" + slug)
-    let info : {id: number, name: string, slug: string, created_date: Date} = 
+    let info : {id: number, name: string, slug: string, created_date: Date} =
         {id: data.data.id, name: data.data.name, slug: data.data.slug, created_date: data.data.created_date};
     return (info);
 }
@@ -24,7 +24,7 @@ project_info(slug : string) : Promise<Object> {
 export async function
 project_stats(projId : number) : Promise<Object> {
     let data = await axios.get("https://api.taiga.io/api/v1/projects/" + projId.toString() + '/stats');
-    
+
     return (data.data);
 }
 
@@ -35,8 +35,6 @@ sprint_stats(sprintId : number) : Promise<Object> {
      return (data.data);
 }
 
-
-
 //This call returns user story  stats based on userstory Id
 export async function
 userstory_statuses(userstoryId : number) : Promise<Object> {
@@ -45,12 +43,39 @@ userstory_statuses(userstoryId : number) : Promise<Object> {
     return (data.data)
 }
 
-
-
 //This call returns task stats based on task Id
 export async function
 task_statuses(taskId : number) : Promise<Object> {
     let data = await axios.get("https://api.taiga.io/api/v1/task-statuses/" + taskId.toString());
     //test link:  https://api.taiga.io/api/v1/task-statuses/1550500
     return (data.data)
+}
+
+/**
+ * @summary Get the History for a task
+ * @param taskId the ID for the task to get history for
+ * @returns array of history objects
+ * {
+ *      date : number,         // Date and time of history entry in milliseconds since epoch
+ *      user : object,         // Taiga User Object
+ *      diff_types : String[], // Names of entries in diff_values
+ *      diff_values : Object   // Values of the changes listed in diff_types
+ * }
+ */
+export async function
+task_history(taskId : number) : Promise<Object> {
+    let data = (await axios.get(`https://api.taiga.io/api/v1/history/task/${taskId}`)).data;
+
+    let output : Array<Object> = [];
+    for(let entry of data) {
+        let new_entry = {
+            date : new Date(entry.created_at).getTime(),
+            user : entry.user,
+            diff_types : Object.keys(entry.diff),
+            diff_values : entry.values_diff
+        }
+        output.push(new_entry);
+    }
+
+    return output;
 }


### PR DESCRIPTION
Function to get History of an Individual Task. It's also documented with a method I think we should adopt.

I used this code to test 
```
(async function(slug) {
  let {id} = await taiga.project_info(slug);

  let sl = await taiga.sprint_list(id);
  let sprint_id = sl[0].id;
  for(let us of await taiga.userstory_list(sprint_id)) {
    console.log(us.id + ":" + us.subject)
    for(let task of await taiga.task_list(us.id)) {
      console.log(task.subject)
      console.log((await taiga.task_history(task.id)));
    }
  }
})("sanaydevi-ser-574");
``` 
Which will print out the history for all tasks in US 1.

but it required these functions in the taiga api:
```
export async function sprint_list(projId : number) : Promise<Object> {
    return (await axios.get(`https://api.taiga.io/api/v1/milestones?project=${projId}`)).data;
}

export async function userstory_list(sprintId : number) : Promise<Object> {
    return (await axios.get(`https://api.taiga.io/api/v1/userstories?milestone=${sprintId}`)).data;
}

export async function task_list(userstoryId : number) : Promise<Object> {
    return (await axios.get(`https://api.taiga.io/api/v1/tasks?user_story=${userstoryId}`)).data;
}
```