### PR TITLE
US247Task249 API call return sprint velocity (unit points) based on sprint Id

### DIFF
--- a/taigit/src/libraries/Taiga.ts
+++ b/taigit/src/libraries/Taiga.ts
@@ -517,6 +517,7 @@ sprint_velocity_pts(sprintId : number) : Promise<number> {
      let entry = {
             pts : data.data.completed_points
         }
+    //velocity calculation according to https://www.scruminc.com/velocity/ 
     let velocity : number = 0;
     for(let each of entry.pts ){
         velocity += each;

--- a/taigit/src/libraries/Taiga.ts
+++ b/taigit/src/libraries/Taiga.ts
@@ -505,23 +505,35 @@ taiga_issues(projId : number) : Promise<Object>{
  * @param sprintId the ID for the access of sprint stats
  * @returns
  * * {
+ *          sprint_end : boolen // if sprint end currently
  *          velocity : number //sprint velocity
  * }
  */
+
+
+
+
 export async function
-sprint_velocity_pts(sprintId : number) : Promise<number> {
-    let data = await axios.get("https://api.taiga.io/api/v1/milestones/"+sprintId.toString()+ '/stats');
+sprint_velocity_pts_date(sprintId : number) : Promise<Object> {
+    let data = (await axios.get("https://api.taiga.io/api/v1/milestones/"+sprintId.toString()+ '/stats')).data;
     //test id:  https://api.taiga.io/api/v1/milestones/205316/stats
     //https://api.taiga.io/api/v1/milestones/219984/stats
+    let current = new Date().getTime();
+    let estimated_finish = new Date(data.estimated_finish).getTime();
+    let sprint_end : boolean = false;
+    if (current > estimated_finish){
+        sprint_end = true;
+    }
 
-     let entry = {
-            pts : data.data.completed_points
-        }
-    //velocity calculation according to https://www.scruminc.com/velocity/ 
+    let entry = {
+            pts : data.completed_points
+    }
+    //velocity calculation according to https://www.scruminc.com/velocity/     
     let velocity : number = 0;
     for(let each of entry.pts ){
         velocity += each;
     }
-
-    return velocity;
+    let velocity_info : {sprint_end : boolean, velocity : number}
+    = {sprint_end : sprint_end , velocity : velocity};
+    return  velocity_info;
 }

--- a/taigit/src/libraries/Taiga.ts
+++ b/taigit/src/libraries/Taiga.ts
@@ -514,7 +514,7 @@ taiga_issues(projId : number) : Promise<Object>{
 
 
 export async function
-sprint_velocity_pts(sprintId : number) : Promise<Object> {
+sprint_velocity_pts(sprintId : number) : Promise<[boolean, number]> {
     let data = (await axios.get("https://api.taiga.io/api/v1/milestones/"+sprintId.toString()+ '/stats')).data;
     //test id:  https://api.taiga.io/api/v1/milestones/205316/stats
     //https://api.taiga.io/api/v1/milestones/219984/stats
@@ -533,7 +533,5 @@ sprint_velocity_pts(sprintId : number) : Promise<Object> {
     for(let each of entry.pts ){
         velocity += each;
     }
-    let velocity_info : {sprint_end : boolean, velocity : number}
-    = {sprint_end : sprint_end , velocity : velocity};
-    return  velocity_info;
+    return  [sprint_end , velocity];
 }

--- a/taigit/src/libraries/Taiga.ts
+++ b/taigit/src/libraries/Taiga.ts
@@ -499,3 +499,28 @@ taiga_issues(projId : number) : Promise<Object>{
     }
     return output;
 }
+
+/**
+ * @summary This call return sprint velocity (unit points) based on sprint Id
+ * @param sprintId the ID for the access of sprint stats
+ * @returns
+ * * {
+ *          velocity : sprint velocity
+ * }
+ */
+export async function
+sprint_velocity_pts(sprintId : number) : Promise<Object> {
+    let data = await axios.get("https://api.taiga.io/api/v1/milestones/"+sprintId.toString()+ '/stats');
+    //test id:  https://api.taiga.io/api/v1/milestones/205316/stats
+    //https://api.taiga.io/api/v1/milestones/219984/stats
+
+     let entry = {
+            pts : data.data.completed_points
+        }
+    let velocity : number = 0;
+    for(let each of entry.pts ){
+        velocity += each;
+    }
+
+    return velocity;
+}

--- a/taigit/src/libraries/Taiga.ts
+++ b/taigit/src/libraries/Taiga.ts
@@ -505,7 +505,7 @@ taiga_issues(projId : number) : Promise<Object>{
  * @param sprintId the ID for the access of sprint stats
  * @returns
  * * {
- *          velocity : sprint velocity
+ *          velocity : number //sprint velocity
  * }
  */
 export async function

--- a/taigit/src/libraries/Taiga.ts
+++ b/taigit/src/libraries/Taiga.ts
@@ -514,7 +514,7 @@ taiga_issues(projId : number) : Promise<Object>{
 
 
 export async function
-sprint_velocity_pts_date(sprintId : number) : Promise<Object> {
+sprint_velocity_pts(sprintId : number) : Promise<Object> {
     let data = (await axios.get("https://api.taiga.io/api/v1/milestones/"+sprintId.toString()+ '/stats')).data;
     //test id:  https://api.taiga.io/api/v1/milestones/205316/stats
     //https://api.taiga.io/api/v1/milestones/219984/stats

--- a/taigit/src/libraries/Taiga.ts
+++ b/taigit/src/libraries/Taiga.ts
@@ -509,7 +509,7 @@ taiga_issues(projId : number) : Promise<Object>{
  * }
  */
 export async function
-sprint_velocity_pts(sprintId : number) : Promise<Object> {
+sprint_velocity_pts(sprintId : number) : Promise<number> {
     let data = await axios.get("https://api.taiga.io/api/v1/milestones/"+sprintId.toString()+ '/stats');
     //test id:  https://api.taiga.io/api/v1/milestones/205316/stats
     //https://api.taiga.io/api/v1/milestones/219984/stats

--- a/taigit/src/libraries/Taiga.ts
+++ b/taigit/src/libraries/Taiga.ts
@@ -509,10 +509,6 @@ taiga_issues(projId : number) : Promise<Object>{
  *          velocity : number //sprint velocity
  * }
  */
-
-
-
-
 export async function
 sprint_velocity_pts(sprintId : number) : Promise<[boolean, number]> {
     let data = (await axios.get("https://api.taiga.io/api/v1/milestones/"+sprintId.toString()+ '/stats')).data;
@@ -524,7 +520,6 @@ sprint_velocity_pts(sprintId : number) : Promise<[boolean, number]> {
     if (current > estimated_finish){
         sprint_end = true;
     }
-
     let entry = {
             pts : data.completed_points
     }


### PR DESCRIPTION
US247Task249 Create a call return sprint velocity (unit points) based on sprint Id

Test Code:
import * as taiga from '../libraries/Taiga';
 {console.log(taiga.sprint_velocity_pts(205316).then((val) => {console.log('fe', val)} ))}

Expected result:
fe 46.5
It indicate sprint velocity is 46.5 for this sprint.