### PR TITLE
us203-task261: Front end to render Task for a single Sprint using Taiga API calls

### DIFF
--- a/taigit/src/actions/taigaActions.js
+++ b/taigit/src/actions/taigaActions.js
@@ -7,8 +7,8 @@ export const GET_SINGLE_SPRINT_STATS = 'GET_SINGLE_SPRINT_STATS'
 export const GET_SPRINT_NAMES = 'GET_SPRINT_NAMES'
 
 /** Thunks (actions that return a function that calls dispatch after async request(s)) */
-export const grabTaigaData = (infoForApiCall) => dispatch => {
-  project_info('sanaydevi-ser-574') // give the slug name
+export const grabTaigaData = (slugName) => dispatch => {
+  project_info(slugName) // give the slug name
 	    .then((taigaProjectInfo) => {
         console.log(taigaProjectInfo);
         dispatch({type: GRAB_TAIGA_DATA, payload: taigaProjectInfo});
@@ -23,17 +23,15 @@ export const grabSprintStats = (infoForApiCall) => dispatch => {
     });
 }
 
-export const grabSingleSprintData = (infoForApiCall) => dispatch => {
-  //get_task_details(sprint_id: number, project_id: any, sprint_name: string)  : Promise<Object> {
-    console.log("GRAB SPRINT DATA");
-    get_task_details(220752, 306316,'Sprint 2 - Taiga')
+export const grabSingleSprintData = (sprintId, projectId, sprintName) => dispatch => {
+  get_task_details(sprintId, projectId, sprintName)
     .then((singleSprintStats) => {
       console.log(singleSprintStats);
       dispatch({type: GET_SINGLE_SPRINT_STATS, payload: singleSprintStats});
     });
 }
-export const grabSprintNames = (infoForApiCall) => dispatch => {
-  sprint_list(306316)
+export const grabSprintNames = (projectId) => dispatch => {
+  sprint_list(projectId)
     .then((sprintData) => {
       dispatch({type: GET_SPRINT_NAMES, payload: sprintData});
     });

--- a/taigit/src/actions/taigaActions.js
+++ b/taigit/src/actions/taigaActions.js
@@ -1,8 +1,9 @@
-import { sprint_stats } from '../libraries/Taiga';
+import { sprint_stats, get_task_details } from '../libraries/Taiga';
 
 /** Actions types */
 export const GRAB_TAIGA_DATA = 'GRAB_TAIGA_DATA'
 export const GET_SPRINT_STATS = 'GET_SPRINT_STATS'
+export const GET_SINGLE_SPRINT_STATS = 'GET_SINGLE_SPRINT_STATS'
 
 /** Thunks (actions that return a function that calls dispatch after async request(s)) */
 export const grabTaigaData = (infoForApiCall) => dispatch => {
@@ -26,5 +27,15 @@ export const grabSprintStats = (infoForApiCall) => dispatch => {
     .then((sprintStats) => {
       console.log(sprintStats);
       dispatch({type: GET_SPRINT_STATS, payload: sprintStats});
+    });
+}
+
+export const grabSingleSprintData = (infoForApiCall) => dispatch => {
+  //get_task_details(sprint_id: number, project_id: any, sprint_name: string)  : Promise<Object> {
+    console.log("GRAB SPRINT DATA");
+    get_task_details(220752, 306316,'Sprint 2 - Taiga')
+    .then((singleSprintStats) => {
+      console.log(singleSprintStats);
+      dispatch({type: GET_SINGLE_SPRINT_STATS, payload: singleSprintStats});
     });
 }

--- a/taigit/src/components/Taiga.js
+++ b/taigit/src/components/Taiga.js
@@ -3,12 +3,13 @@ import Select from 'react-select'
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Doughnut, Bar, Line } from 'react-chartjs-2';
-import { grabTaigaData, grabSprintStats } from '../actions/taigaActions';
+import { grabTaigaData, grabSprintStats, grabSingleSprintData } from '../actions/taigaActions';
 import {
   selectSprintList,
   selectSprintProgressChartData,
   selectUserTaskDistributionChartData,
-  selectSprintBurndownChartData
+  selectSprintBurndownChartData,
+  selectSingleSprintData
 } from '../reducers';
 import { saveLayoutToLocalStorage, getLayoutFromLocalStorage } from '../utils/utils';
 import { WidthProvider, Responsive } from "react-grid-layout";
@@ -43,6 +44,7 @@ class Taiga extends Component {
   componentWillMount() {
     this.props.grabTaigaData();
     this.props.grabSprintStats();
+    this.props.grabSingleSprintData();
     originalLayouts = getLayoutFromLocalStorage(layoutname, 'layouts') || [];
     this.setState({ layouts: JSON.parse(JSON.stringify(originalLayouts)) });
   }
@@ -89,13 +91,43 @@ class Taiga extends Component {
             <Line data={this.props.burnDownData} options={burndownOptions}/>
             </div>
           </div>
+          <div className='box' key="4" data-grid={{ w: 5, h: 10, x: 5, y: 0, minW: 0, minH: 0 }}>
+            <div className="chart">
+              <span className="chart-title">Single Sprint Taiga Task</span>
+              <Bar data={this.props.singleSprintData} options={barGraphOptions}/>
+            </div>
+          </div>
           <h4>{this.props.storeData}</h4>
         </ResponsiveReactGridLayout>
       </div>
     );
   }
 }
+const barGraphOptions = {
+  maintainAspectRatio: true,
+  responsive: true,
+  scales: {
+    yAxes: [{
+      scaleLabel:{
+        display: true,
+        labelString: "Count"
+      },
+      ticks: {
+        autoSkip: false
+      }
+    }],
 
+    xAxes: [{
+      scaleLabel:{
+        display: true,
+        labelString: "Contributors"
+      },
+      ticks: {
+        autoSkip: false
+      }
+    }]
+    }
+}
 const burndownOptions = {
     plotOptions: {
       line: {
@@ -154,11 +186,12 @@ const mapStateToProps = state => ({
   sprintProgress: selectSprintProgressChartData(state),
   userTaskDistribution: selectUserTaskDistributionChartData(state),
   sprintList: selectSprintList(state),
-  burnDownData: selectSprintBurndownChartData(state)
+  burnDownData: selectSprintBurndownChartData(state),
+  singleSprintData: selectSingleSprintData(state),
 });
 
 /**
  * connect(mapStateToProps, actions)(componentName)
  * connects the component to the redux store
  */
-export default connect(mapStateToProps, { grabTaigaData, grabSprintStats })(Taiga)
+export default connect(mapStateToProps, { grabTaigaData, grabSprintStats, grabSingleSprintData})(Taiga)

--- a/taigit/src/components/Taiga.js
+++ b/taigit/src/components/Taiga.js
@@ -42,10 +42,10 @@ class Taiga extends Component {
   }
 
   componentWillMount() {
-    this.props.grabTaigaData();
+    this.props.grabTaigaData('sanaydevi-ser-574');
+    this.props.grabSprintNames(306316);
     this.props.grabSprintStats();
-    this.props.grabSingleSprintData();
-    this.props.grabSprintNames();
+    this.props.grabSingleSprintData(220752, 306316,'Sprint 2 - Taiga');
     originalLayouts = getLayoutFromLocalStorage(layoutname, 'layouts') || [];
     this.setState({ layouts: JSON.parse(JSON.stringify(originalLayouts)) });
   }
@@ -78,12 +78,6 @@ class Taiga extends Component {
             <div className="chart chart-pie">
               <span className="chart-title">Task Progress</span>
               <Doughnut data={this.props.sprintProgress} options={{maintainAspectRatio: true, responsive: true}}/>
-            </div>
-          </div>
-          <div className='box' key="2" data-grid={{ w: 5, h: 10, x: 3, y: 0, minW: 0, minH: 0 }}>
-            <div className="chart">
-              <span className="chart-title">Taiga Tasks</span>
-              <Bar data={this.props.userTaskDistribution} options={{maintainAspectRatio: true, responsive: true}}/>
             </div>
           </div>
           <div className='box' key="3" data-grid={{ w: 5, h: 10, x: 5, y: 0, minW: 0, minH: 0 }}>

--- a/taigit/src/reducers/index.js
+++ b/taigit/src/reducers/index.js
@@ -19,3 +19,4 @@ export const selectCommitsPerContributorChartData = (state) => fromGithub.select
 export const selectNumBranchCommits = (state) => fromGithub.selectNumBranchCommits(state.github);
 export const selectSprintBurndownChartData = (state) => fromTaiga.selectSprintBurndownChartData(state.taiga);
 export const selectNumPullRequestsClosedData = (state) => fromGithub.selectNumPullRequestsClosedData(state.github);
+export const selectSingleSprintData = (state) => fromTaiga.selectSingleSprintData(state.taiga);

--- a/taigit/src/styles/colors.js
+++ b/taigit/src/styles/colors.js
@@ -24,6 +24,11 @@ const colors = {
     dark: '#DD6A11',
     light: '#F2A56B',
   },
+  green: {
+    base: '#00FF00',
+    dark: '#006400',
+    light:'#98FB98',
+  },
   none: '#DFE2D2'
 };
 


### PR DESCRIPTION
This PR is for showing Task status for a single spirnt. Currently projectId, sprintId and sprint name is hardcoded in the code. The below image show data about 2nd sprint of Taiga. Also please suggest some good chart Title.

<img width="642" alt="Screen Shot 2019-03-29 at 3 22 35 PM" src="https://user-images.githubusercontent.com/43048349/55266060-53422200-5238-11e9-89d8-adba40cdeddb.png">
