### PR TITLE
US191T239 Add retrospective checking function

### DIFF
--- a/taigit/src/libraries/Taiga.ts
+++ b/taigit/src/libraries/Taiga.ts
@@ -177,6 +177,45 @@ interface spr_stats {
     burndown: Object[]
 }
 
+/**
+ * @summary interface for wikipages
+ * @param id: number,            // wiki page id
+ * @param slug: String,          // wiki page slug(basically the title)
+ * @param content: String,       // markdown content
+ * @param owner: number,         // user_id of owner
+ * @param last_modifier: number, // user_id of person to last_modify it
+ * @param created_date: String,  // created date
+ * @param modified_date: String, // last modified date
+ * @param version: number        // number of edits
+ */
+interface wiki_page {
+    project: number,
+    id: number,
+    slug: string,
+    content: string,
+    owner: number,
+    last_modifier: number,
+    created_date: string,
+    modified_date: string,
+    editions: number,
+    version: number
+}
+
+//helper_functions
+function check_date_in_range(center_date : Date, day_range : number, input_date : Date) {
+    //day_range is +- number of days from date.
+
+    let date_start = new Date(center_date);
+    date_start.setDate(date_start.getDate()-day_range);
+
+    let date_end = new Date(center_date);
+    date_end.setDate(date_end.getDate()+day_range);
+    return input_date >= date_start && input_date <= date_end;
+}
+
+function get_days_between_dates(start : Date, end : Date) : number {
+    return Math.round((end.getTime()-start.getTime())/(1000*60*60*24));
+}
 
 // API Calls
 /**
@@ -302,7 +341,7 @@ project_stats(projId : number) : Promise<Object> {
  * @returns spr_stats interface
  */
 export async function
-sprint_stats(sprintId : number) : Promise<Object> {
+sprint_stats(sprintId : number) : Promise<spr_stats> {
     let data = await axios.get("https://api.taiga.io/api/v1/milestones/"+sprintId.toString()+ '/stats');
     let info : spr_stats = {completed_pts: data.data.completed_points, total_pts: data.data.total_points,
                             completed_tsks: data.data.completed_tasks, total_tsks: data.data.total_tasks,
@@ -372,9 +411,9 @@ task_history(taskId : number) : Promise<Object> {
  * @returns project wiki
  */
 export async function
-project_wiki(projectId : number) : Promise<Object> {
+project_wiki(projectId : number) : Promise<wiki_page[]> {
     let data = await axios.get("https://api.taiga.io/api/v1/wiki?project="+projectId.toString());
-  
+
     return (data.data);
 }
 
@@ -790,11 +829,52 @@ task_of_sprint(sprintId : number) : Promise <Object[]>  {
  */
 export async function
 task_of_us(usId : number) : Promise <Object[]>  {
-        let output : Array<Object> = [];
-        let task_list = (await axios.get(`https://api.taiga.io/api/v1/tasks?user_story=${usId}`)).data;
-        for(let task of task_list){
-            let data =(await task_assessment(task.id));
-            output.push(data);
+    let output : Array<Object> = [];
+    let task_list = (await axios.get(`https://api.taiga.io/api/v1/tasks?user_story=${usId}`)).data;
+    for(let task of task_list){
+        let data =(await task_assessment(task.id));
+        output.push(data);
+    }
+    return output;
+}
+
+/**
+ * @summary check if a retrospective for a particular sprint exists
+ * @param project_id : number
+ * @param sprint_id : number
+ */
+export async function
+check_for_retrospective(project_id : number, sprint_id : number) : Promise<wiki_page | undefined> {
+    //get info from taiga
+    let { sprint_start, sprint_end } = await sprint_stats(sprint_id);
+    let wiki_pages : wiki_page[] = await project_wiki(project_id);
+
+    //find searchable date range
+    let sprint_len = get_days_between_dates(new Date(sprint_start), new Date(sprint_end));
+    let day_diff: number = 3;
+    if(sprint_len <= 7) {
+        //if sprint length is 1 week, search +-1 day
+        day_diff = 1;
+    } else if(sprint_len <= 14) {
+        //if sprint length is 2 weeks, search +-2 days
+        day_diff = 2;
+    } else {
+        //otherwise search +-3 days
+        day_diff = 3;
+    }
+
+
+    let retro_page : wiki_page | undefined = undefined;
+    for(let entry of wiki_pages) {
+        //check wikipage title for the word "retrospective"
+        if(/.?(retrospective).?/gmi.test(entry.slug)) {
+            //then check that it's "last_modified" date is with an acceptable range from the end of the sprint
+            if(check_date_in_range(new Date(sprint_end), day_diff, new Date(entry.modified_date))) {
+                //if page matches, then return it.
+                retro_page = entry;
+                break;
+            }
         }
-        return output;
+    }
+    return retro_page;
 }


### PR DESCRIPTION
check for a wikipage containing the keyword "retrospective" within a range of days from the end of the sprint. 
return either the particular wiki page object or undefined if none were found.

this also adds a wiki_page object, some helper date processing functions, and fixes the return types of the `sprint_stats` and `project_wiki` functions

simple to test, put this somewhere in the taiga component or something an run it. 
`(async () => { console.log(await check_for_retrospective(306316,217974)); })()`