### PR TITLE
US187 Task 246 Return list of  task assessment based on user story id

### DIFF
--- a/taigit/src/libraries/Taiga.ts
+++ b/taigit/src/libraries/Taiga.ts
@@ -657,3 +657,19 @@ eval_userstories(sprintId : number) : Promise<Object>{
     });
     return us_subjects;
 }
+
+/**
+ * @summary This call returns task assessment list based on us Id
+ * @param us Id the ID for the user story to get associated task for
+ * @returns Array of task assessment Object
+ */
+export async function
+task_of_us(usId : number) : Promise <Object[]>  {
+        let output : Array<Object> = [];
+        let task_list = (await axios.get(`https://api.taiga.io/api/v1/tasks?user_story=${usId}`)).data;
+        for(let task of task_list){
+            let data =(await task_assessment(task.id));
+            output.push(data);
+        }
+        return output;
+    }


### PR DESCRIPTION
US187 Task 246 Create a APT  will Return list of  task assessment based on user story id.
To test:
Include "task_assessment" API in the taiga.ts.
add the following in the taiga.js
import * as taiga from '../libraries/Taiga';
{console.log(taiga.task_of_us(2455141).then((val) => {console.log('fe', val)} ))}


expected result:
fe Array(5) 0: {task_valid: true, finished: true, end_status: "Closed", num_stat: 3, fin_per: 100, …} 1: {task_valid: true, finished: true, end_status: "Closed", num_stat: 3, fin_per: 100, …} 2: {task_valid: true, finished: true, end_status: "Closed", num_stat: 3, fin_per: 100, …} 3: {task_valid: true, finished: true, end_status: "Closed", num_stat: 3, fin_per: 100, …} 4: {task_valid: true, finished: true, end_status: "Closed", num_stat: 3, fin_per: 100, …} length: 5 __proto__: Array(0)