### PR TITLE
US187Task260 API return list of  task assessment based on sprint id

### DIFF
--- a/taigit/src/libraries/Taiga.ts
+++ b/taigit/src/libraries/Taiga.ts
@@ -657,3 +657,20 @@ eval_userstories(sprintId : number) : Promise<Object>{
     });
     return us_subjects;
 }
+
+
+/**
+ * @summary This call returns task assessment list based on sprint Id
+ * @param sprint Id the ID for the sprint to get associated task for
+ * @returns Array of Array of task assessment Object
+ */
+export async function
+task_of_sprint(sprintId : number) : Promise <Object[]>  {
+    let output : Array<Object> = [];
+    let us_list= (await axios.get(`https://api.taiga.io/api/v1/userstories?milestone=${sprintId}`)).data;
+     for(let us of us_list ) {
+         let task_assess = task_of_us(us.id);
+         output.push(task_assess);
+     }
+    return output;
+}


### PR DESCRIPTION
US187Task260 create API return list of  task assessment based on sprint id

To test:
Include "task_assessment" and "task_of_us" API in the taiga.ts.
add the following in the taiga.js
import * as taiga from '../libraries/Taiga';
 {console.log(taiga.task_of_sprint(205316).then((val) => {console.log('fe', val)} ))}

Expected result:
fe Array(12) 0: Promise __proto__: Promise [[PromiseStatus]]: "resolved" [[PromiseValue]]: Array(5) 0: {task_valid: true, finished: true, end_status: "Closed", num_stat: 3, fin_per: 100, …} 1: {task_valid: true, finished: true, end_status: "Closed", num_stat: 3, fin_per: 100, …} 2: {task_valid: true, finished: true, end_status: "Closed", num_stat: 3, fin_per: 100, …} 3: {task_valid: true, finished: true, end_status: "Closed", num_stat: 3, fin_per: 100, …} 4: {task_valid: true, finished: true, end_status: "Closed", num_stat: 3, fin_per: 100, …} length: 5 __proto__: Array(0) 1: Promise {<resolved>: Array(5)} 2: Promise {<resolved>: Array(4)} 3: Promise {<resolved>: Array(4)} 4: Promise {<resolved>: Array(4)} 5: Promise {<resolved>: Array(4)} 6: Promise {<pending>} 7: Promise {<pending>} 8: Promise {<resolved>: Array(2)} 9: Promise {<resolved>: Array(3)} 10: Promise {<resolved>: Array(3)} 11: Promise {<resolved>: Array(5)} length: 12 __proto__: Array(0)