### PR TITLE
Us 204 project page

### DIFF
--- a/taigit/src/actions/githubActions.js
+++ b/taigit/src/actions/githubActions.js
@@ -6,7 +6,8 @@ import {
   getNumBranchCommits,
   getNumComments,
   getAuthToken,
-  getMemberInfo} from '../libraries/GitHub/GitHub';
+  getMemberInfo,
+  getUserRepos} from '../libraries/GitHub/GitHub';
 import { getFromLocalStorage, saveToLocalStorage } from '../utils/utils';
 
 /** Actions types */
@@ -18,6 +19,7 @@ export const GET_NUM_BRANCH_COMMITS = 'GET_NUM_BRANCH_COMMITS';
 export const ADD_AUTH_KEY = 'ADD_AUTH_KEY';
 export const GET_PULL_REQUESTS_CLOSED = 'GET_PULL_REQUESTS_CLOSED';
 export const GET_AVG_COMMENTS_PR = 'GET_AVG_COMMENTS_PR';
+export const ADD_USER_REPOS = 'ADD_USER_REPOS';
 
 /** Thunks (actions that return a function that calls dispatch after async request(s)) */
 export const getBranchList = (owner, repo, auth) => dispatch => {
@@ -26,6 +28,26 @@ export const getBranchList = (owner, repo, auth) => dispatch => {
     .then(branches =>
       dispatch({type: GET_BRANCH_LIST, payload: branches})
     );
+}
+
+export const getUsersRepos = (owner, auth) => dispatch => {
+  console.log('about to get all user owned repos');
+  getUserRepos(owner, auth)
+    .then(repos => {
+      try {
+        const userReposTrimmed = repos.map((repo) => {
+          let trimmedRepo = {};
+          trimmedRepo.id = repo.id;
+          trimmedRepo.name = repo.name;
+          trimmedRepo.full_name = repo.full_name;
+          trimmedRepo.owner = repo.owner.login;
+          return trimmedRepo;
+        })
+        dispatch({type: ADD_USER_REPOS, payload: userReposTrimmed});
+      } catch (e) {
+        console.error(e);
+      }
+    });
 }
 
 export const getCommitsPerUser = (owner, repo, author, auth) => dispatch => {

--- a/taigit/src/actions/githubActions.js
+++ b/taigit/src/actions/githubActions.js
@@ -7,7 +7,9 @@ import {
   getNumComments,
   getAuthToken,
   getMemberInfo,
-  getUserRepos} from '../libraries/GitHub/GitHub';
+  getUserRepos,
+  getUserInfo
+} from '../libraries/GitHub/GitHub';
 import { getFromLocalStorage, saveToLocalStorage } from '../utils/utils';
 
 /** Actions types */
@@ -20,6 +22,7 @@ export const ADD_AUTH_KEY = 'ADD_AUTH_KEY';
 export const GET_PULL_REQUESTS_CLOSED = 'GET_PULL_REQUESTS_CLOSED';
 export const GET_AVG_COMMENTS_PR = 'GET_AVG_COMMENTS_PR';
 export const ADD_USER_REPOS = 'ADD_USER_REPOS';
+export const ADD_USER_INFO = 'ADD_USER_INFO';
 
 /** Thunks (actions that return a function that calls dispatch after async request(s)) */
 export const getBranchList = (owner, repo, auth) => dispatch => {
@@ -126,5 +129,13 @@ export const getAvgCommentsPR = (owner, repo, auth) => dispatch => {
   getNumComments(owner, repo, auth)
     .then(avgNumberofComments =>
       dispatch({type: GET_AVG_COMMENTS_PR, payload: avgNumberofComments})
+    );
+}
+
+export const addUserInfo = (auth) => dispatch => {
+  console.log('about to get user object');
+  getUserInfo(auth)
+    .then(userInfo => 
+      dispatch({type: ADD_USER_INFO, payload: userInfo})
     );
 }

--- a/taigit/src/actions/taigaActions.js
+++ b/taigit/src/actions/taigaActions.js
@@ -32,8 +32,8 @@ export const setTaigaProjectID = (slugName) => dispatch => {
         });
 }
 
-export const grabSprintStats = (infoForApiCall) => dispatch => {
-  sprint_stats(220659)
+export const grabSprintStats = (sprintID) => dispatch => {
+  sprint_stats(sprintID)
     .then((sprintStats) => {
       console.log(sprintStats);
       dispatch({type: GET_SPRINT_STATS, payload: sprintStats});

--- a/taigit/src/actions/taigaActions.js
+++ b/taigit/src/actions/taigaActions.js
@@ -14,14 +14,14 @@ export const GET_SPRINT_NAMES = 'GET_SPRINT_NAMES'
 export const GET_TASK_STATS = 'GET_TASK_STATS'
 export const TAIGA_LOGIN = 'TAIGA_LOGIN'
 export const GET_USER_PROJECTS = 'GET_USER_PROJECTS'
+export const LOADING_TAIGA_DATA = 'LOADING_TAIGA_DATA';
 
 /** Thunks (actions that return a function that calls dispatch after async request(s)) */
-export const grabTaigaData = (slugName) => dispatch => {
-  project_info(slugName) // give the slug name
-	    .then((taigaProjectInfo) => {
-        console.log(taigaProjectInfo);
-        dispatch({type: GRAB_TAIGA_DATA, payload: taigaProjectInfo});
-      });
+
+export const grabTaigaData = (slugName) => async(dispatch) => {
+  const taigaProjectInfo = await project_info(slugName);
+  taigaProjectInfo.slugName = slugName;
+  dispatch({type: GRAB_TAIGA_DATA, payload: taigaProjectInfo});
 }
 
 export const setTaigaProjectID = (slugName) => dispatch => {
@@ -86,4 +86,17 @@ export const initializeUserData = (username, password) => dispatch => {
         .then((projectList) => {
             dispatch({type: GET_USER_PROJECTS, payload: projectList});
         });
+}
+
+export const loadAllTaigaProjectData = (slugName) => async (dispatch) => {
+  dispatch({type: LOADING_TAIGA_DATA, payload: true});
+
+  const taigaProject = await project_info(slugName);
+  taigaProject.slugName = slugName;
+  dispatch({type: GRAB_TAIGA_DATA, payload: taigaProject});
+
+  const sprintNames = await sprint_list(taigaProject.id);
+  dispatch({type: GET_SPRINT_NAMES, payload: sprintNames});
+
+  dispatch({type: LOADING_TAIGA_DATA, payload: false});
 }

--- a/taigit/src/actions/taigaActions.js
+++ b/taigit/src/actions/taigaActions.js
@@ -91,12 +91,30 @@ export const initializeUserData = (username, password) => dispatch => {
 export const loadAllTaigaProjectData = (slugName) => async (dispatch) => {
   dispatch({type: LOADING_TAIGA_DATA, payload: true});
 
+  // Load basic project info
   const taigaProject = await project_info(slugName);
   taigaProject.slugName = slugName;
+  saveToLocalStorage('taiga-project-id', taigaProject.id);
   dispatch({type: GRAB_TAIGA_DATA, payload: taigaProject});
 
-  const sprintNames = await sprint_list(taigaProject.id);
-  dispatch({type: GET_SPRINT_NAMES, payload: sprintNames});
+  // Load task stats for entire project
+  const projectTaskStats = await get_task_status_count(taigaProject.id);
+  dispatch({type: GET_TASK_STATS, payload: projectTaskStats});
+
+  // Load list of sprint names
+  const sprintList = await sprint_list(taigaProject.id);
+  dispatch({type: GET_SPRINT_NAMES, payload: sprintList});
+
+  const firstSprintID = sprintList[0].id;
+  const firstSprintName = sprintList[0].name;
+
+  // Load stats of the first sprint
+  const firstSprintStats = await sprint_stats(firstSprintID);
+  dispatch({type: GET_SPRINT_STATS, payload: firstSprintStats});
+
+  // Load task details for the first sprint
+  const firstSprintTaskDetails = await get_task_details(firstSprintID, taigaProject.id, firstSprintName);
+  dispatch({type: GET_SINGLE_SPRINT_STATS, payload: firstSprintTaskDetails});
 
   dispatch({type: LOADING_TAIGA_DATA, payload: false});
 }

--- a/taigit/src/actions/taigaActions.js
+++ b/taigit/src/actions/taigaActions.js
@@ -1,8 +1,10 @@
 import { 
   project_info, sprint_list, 
   get_task_details, sprint_stats, 
-  get_task_status_count 
+  get_task_status_count,
+  taiga_login, get_projects_for_user
 } from '../libraries/Taiga';
+import {saveToLocalStorage} from "../utils/utils";
 
 /** Actions types */
 export const GRAB_TAIGA_DATA = 'GRAB_TAIGA_DATA'
@@ -10,6 +12,8 @@ export const GET_SPRINT_STATS = 'GET_SPRINT_STATS'
 export const GET_SINGLE_SPRINT_STATS = 'GET_SINGLE_SPRINT_STATS'
 export const GET_SPRINT_NAMES = 'GET_SPRINT_NAMES'
 export const GET_TASK_STATS = 'GET_TASK_STATS'
+export const TAIGA_LOGIN = 'TAIGA_LOGIN'
+export const GET_USER_PROJECTS = 'GET_USER_PROJECTS'
 
 /** Thunks (actions that return a function that calls dispatch after async request(s)) */
 export const grabTaigaData = (slugName) => dispatch => {
@@ -18,6 +22,14 @@ export const grabTaigaData = (slugName) => dispatch => {
         console.log(taigaProjectInfo);
         dispatch({type: GRAB_TAIGA_DATA, payload: taigaProjectInfo});
       });
+}
+
+export const setTaigaProjectID = (slugName) => dispatch => {
+    project_info(slugName) // give the slug name
+        .then((taigaProjectInfo) => {
+            saveToLocalStorage('taiga-project-id', taigaProjectInfo.id);
+            dispatch({type: GRAB_TAIGA_DATA, payload: taigaProjectInfo});
+        });
 }
 
 export const grabSprintStats = (infoForApiCall) => dispatch => {
@@ -45,4 +57,33 @@ export const grabSprintNames = (projectId) => dispatch => {
     .then((sprintData) => {
       dispatch({type: GET_SPRINT_NAMES, payload: sprintData});
     });
+}
+
+export const grabTaigaUserId = (taigaId, taigaPass) => dispatch => {
+    taiga_login(taigaId, taigaPass)
+        .then((loginData) => {
+            dispatch({type: TAIGA_LOGIN, payload: loginData});
+        });
+}
+
+export const grabUserProjects = (userId) => dispatch => {
+    get_projects_for_user(userId)
+        .then((projectList) => {
+            dispatch({type: GET_USER_PROJECTS, payload: projectList});
+        });
+}
+
+export const initializeUserData = (username, password) => dispatch => {
+    taiga_login(username, password)
+        .then((loginData) => {
+            dispatch({type: TAIGA_LOGIN, payload: loginData});
+            return loginData.id;
+        })
+        .then((userId) => {
+            saveToLocalStorage('taiga-user-id', userId);
+            return get_projects_for_user(userId);
+        })
+        .then((projectList) => {
+            dispatch({type: GET_USER_PROJECTS, payload: projectList});
+        });
 }

--- a/taigit/src/components/GitHub.js
+++ b/taigit/src/components/GitHub.js
@@ -7,7 +7,8 @@ import {
   getContributorData,
   getBranchCommits,
   getAvgCommentsPR,
-  getMembersInfo } from '../actions/githubActions';
+  getMembersInfo,
+  getUsersRepos } from '../actions/githubActions';
 import {
   selectBranchList,
   selectNumCommitsChartData,
@@ -55,6 +56,7 @@ class GitHub extends Component {
   componentWillMount() {
     let auth = getFromLocalStorage('auth-key');
     console.log('auth key is', auth);
+    this.props.getUsersRepos('trevorforrey', auth);
     this.props.getBranchList('ser574-green-team', 'taigit', auth);
     this.props.getCommitsPerUser('trevorforrey', 'OttoDB', 'trevorforrey', auth);
     this.props.getPullRequests('ser574-green-team', 'taigit', auth);
@@ -152,4 +154,12 @@ const mapStateToProps = state => ({
  * connects the component to the redux store
  */
 export default connect(mapStateToProps, {
-  getBranchList, getCommitsPerUser, getPullRequests, getContributorData, getBranchCommits, getAvgCommentsPR , getMembersInfo })(GitHub)
+  getBranchList,
+  getCommitsPerUser,
+  getPullRequests,
+  getContributorData,
+  getBranchCommits,
+  getAvgCommentsPR,
+  getMembersInfo,
+  getUsersRepos
+})(GitHub)

--- a/taigit/src/components/GitHub.js
+++ b/taigit/src/components/GitHub.js
@@ -1,14 +1,8 @@
 import React, { Component } from 'react';
 import NumberDisplay from './NumberDisplay'
 import {
-  getBranchList,
-  getCommitsPerUser,
-  getPullRequests,
-  getContributorData,
-  getBranchCommits,
-  getAvgCommentsPR,
-  getMembersInfo,
-  getUsersRepos } from '../actions/githubActions';
+  loadAllGitHubProjectData
+} from '../actions/githubActions';
 import {
   selectBranchList,
   selectNumCommitsChartData,
@@ -56,18 +50,11 @@ class GitHub extends Component {
 
   // Calls methods in actions/githubActions to fetch data from API
   componentWillMount() {
-    let auth = getFromLocalStorage('auth-key');
-    this.props.getUsersRepos(this.state.githubOwner, auth);
-    this.props.getBranchList(this.state.githubOwner, this.state.githubRepo, auth);
-    this.props.getCommitsPerUser(this.state.githubOwner, this.state.githubRepo, 'trevorforrey', auth);
-    this.props.getPullRequests(this.state.githubOwner, this.state.githubRepo, auth);
-    this.props.getContributorData(this.state.githubOwner, this.state.githubRepo, auth);
-    this.props.getBranchCommits(this.state.githubOwner, this.state.githubRepo, 'master', auth);
-    this.props.getBranchCommits(this.state.githubOwner, this.state.githubRepo, 'dev', auth);
-    this.props.getMembersInfo(this.state.githubOwner, auth);
-    //this.props.getPullRequestsClosed(this.state.githubOwner, this.state.githubRepo, auth);
-    this.props.getAvgCommentsPR(this.state.githubOwner, this.state.githubRepo, auth);
-
+    // Handle if user refreshes on GitHub page
+    if (this.props.branches.length == 0) {
+      const auth = getFromLocalStorage('auth-key');
+      this.props.loadAllGitHubProjectData(this.state.githubOwner, this.state.githubRepo, auth);
+    }
     originalLayouts = getLayoutFromLocalStorage(layoutname, 'layouts') || [];
     this.setState({ layouts: JSON.parse(JSON.stringify(originalLayouts)) });
   }
@@ -124,18 +111,6 @@ class GitHub extends Component {
   }
 }
 
-const horizontalChartOptions = {
-  responsive: true,
-  maintainAspectRatio: true,
-  scales: {
-      yAxes: [{
-          ticks: {
-              beginAtZero:true
-          }
-      }]
-  }
-}
-
 /**
  * mapStateToProps
  * maps state in redux store (right)
@@ -154,13 +129,4 @@ const mapStateToProps = state => ({
  * connect(mapStateToProps, actions)(componentName)
  * connects the component to the redux store
  */
-export default connect(mapStateToProps, {
-  getBranchList,
-  getCommitsPerUser,
-  getPullRequests,
-  getContributorData,
-  getBranchCommits,
-  getAvgCommentsPR,
-  getMembersInfo,
-  getUsersRepos
-})(GitHub)
+export default connect(mapStateToProps, { loadAllGitHubProjectData })(GitHub)

--- a/taigit/src/components/GitHub.js
+++ b/taigit/src/components/GitHub.js
@@ -35,7 +35,9 @@ class GitHub extends Component {
     super(props);
 
     this.state = {
-      layouts: JSON.parse(JSON.stringify(originalLayouts))
+      layouts: JSON.parse(JSON.stringify(originalLayouts)),
+      githubOwner: getFromLocalStorage('github-owner') || '',
+      githubRepo: getFromLocalStorage('github-repo') || ''
     };
   }
   
@@ -55,17 +57,16 @@ class GitHub extends Component {
   // Calls methods in actions/githubActions to fetch data from API
   componentWillMount() {
     let auth = getFromLocalStorage('auth-key');
-    console.log('auth key is', auth);
-    this.props.getUsersRepos('trevorforrey', auth);
-    this.props.getBranchList('ser574-green-team', 'taigit', auth);
-    this.props.getCommitsPerUser('trevorforrey', 'OttoDB', 'trevorforrey', auth);
-    this.props.getPullRequests('ser574-green-team', 'taigit', auth);
-    this.props.getContributorData('ser574-green-team', 'taigit', auth);
-    this.props.getBranchCommits('ser574-green-team', 'taigit', 'master', auth);
-    this.props.getBranchCommits('ser574-green-team', 'taigit', 'dev', auth);
-    this.props.getMembersInfo('ser574-green-team', auth);
-    //this.props.getPullRequestsClosed('ser574-green-team', 'taigit', auth);
-    this.props.getAvgCommentsPR('ser574-green-team', 'taigit', auth);
+    this.props.getUsersRepos(this.state.githubOwner, auth);
+    this.props.getBranchList(this.state.githubOwner, this.state.githubRepo, auth);
+    this.props.getCommitsPerUser(this.state.githubOwner, this.state.githubRepo, 'trevorforrey', auth);
+    this.props.getPullRequests(this.state.githubOwner, this.state.githubRepo, auth);
+    this.props.getContributorData(this.state.githubOwner, this.state.githubRepo, auth);
+    this.props.getBranchCommits(this.state.githubOwner, this.state.githubRepo, 'master', auth);
+    this.props.getBranchCommits(this.state.githubOwner, this.state.githubRepo, 'dev', auth);
+    this.props.getMembersInfo(this.state.githubOwner, auth);
+    //this.props.getPullRequestsClosed(this.state.githubOwner, this.state.githubRepo, auth);
+    this.props.getAvgCommentsPR(this.state.githubOwner, this.state.githubRepo, auth);
 
     originalLayouts = getLayoutFromLocalStorage(layoutname, 'layouts') || [];
     this.setState({ layouts: JSON.parse(JSON.stringify(originalLayouts)) });
@@ -74,7 +75,7 @@ class GitHub extends Component {
   render() {
     return(
       <div className="app-page">
-        <h2>GitHub</h2>
+        <h2>GitHub Repository: <p style={{display: 'inline', color: colors.blue.base}}>{this.state.githubRepo}</p></h2>
         <ResponsiveReactGridLayout
           className="layout"
           cols={{ lg: 12, md: 10, sm: 6, xs: 4, xxs: 2 }}

--- a/taigit/src/components/Overview.js
+++ b/taigit/src/components/Overview.js
@@ -7,7 +7,9 @@ import colors from '../styles/colors';
 import { Bar } from 'react-chartjs-2';
 import { selectUserTaskDistributionChartData } from '../reducers';
 import { connect } from 'react-redux';
-import { grabTaskStats } from '../actions/taigaActions';
+import { loadAllTaigaProjectData } from '../actions/taigaActions';
+import { loadAllGitHubProjectData } from '../actions/githubActions';
+import { selectTaigaProjectData } from '../reducers';
 
 const ResponsiveReactGridLayout = WidthProvider(Responsive);
 const layoutname = 'overview-layout';
@@ -20,8 +22,9 @@ class Overview extends Component {
 
     this.state = {
       layouts: JSON.parse(JSON.stringify(originalLayouts)),
-      ghRepo: getFromLocalStorage('github-repo'),
-      taigaSlug: getFromLocalStorage('taiga-slug')
+      taigaSlug: getFromLocalStorage('taiga-slug') || '',
+      githubOwner: getFromLocalStorage('github-owner') || '',
+      githubRepo: getFromLocalStorage('github-repo') || ''
     };
   }
 
@@ -39,7 +42,12 @@ class Overview extends Component {
   }
 
   componentWillMount() {
-    this.props.grabTaskStats(306316);
+    // Handle if user refreshes on overview page
+    if (Object.keys(this.props.taigaProjectData).length == 0) {
+      const auth = getFromLocalStorage('auth-key');
+      loadAllTaigaProjectData(this.state.taigaSlug);
+      loadAllGitHubProjectData(this.state.githubOwner, this.state.githubRepo, auth);
+    }
     originalLayouts = getLayoutFromLocalStorage(layoutname, 'layouts') || [];
     this.setState({ layouts: JSON.parse(JSON.stringify(originalLayouts)) });
   }
@@ -47,8 +55,8 @@ class Overview extends Component {
   render() {
     return (
       <div className="app-page">
-        <h2>Overview: <p style={{color: colors.orange.base, display: 'inline'}}>
-            {this.state.ghRepo}</p> | <p style={{color:colors.green.base, display: 'inline'}}>
+        <h2>Overview: <p style={{color: colors.blue.base, display: 'inline'}}>
+            {this.state.githubRepo}</p> | <p style={{color:colors.red.base, display: 'inline'}}>
             {this.state.taigaSlug}</p></h2>
         <ResponsiveReactGridLayout
           className="layout"
@@ -142,5 +150,9 @@ const barGraphOptions = {
 }
 const mapStateToProps = state => ({
   taigaTaskDistribution: selectUserTaskDistributionChartData(state),
+  taigaProjectData: selectTaigaProjectData(state)
 });
-export default connect(mapStateToProps, { grabTaskStats })(Overview)
+export default connect(mapStateToProps, { 
+  loadAllGitHubProjectData,
+  loadAllTaigaProjectData
+})(Overview)

--- a/taigit/src/components/Overview.js
+++ b/taigit/src/components/Overview.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import NumberDisplay from './NumberDisplay'
 import {Doughnut, Line} from 'react-chartjs-2';
-import { saveLayoutToLocalStorage, getLayoutFromLocalStorage } from '../utils/utils';
+import {saveLayoutToLocalStorage, getLayoutFromLocalStorage, getFromLocalStorage} from '../utils/utils';
 import { WidthProvider, Responsive } from "react-grid-layout";
 import colors from '../styles/colors';
 import { Bar } from 'react-chartjs-2';
@@ -19,7 +19,9 @@ class Overview extends Component {
     super(props);
 
     this.state = {
-      layouts: JSON.parse(JSON.stringify(originalLayouts))
+      layouts: JSON.parse(JSON.stringify(originalLayouts)),
+      ghRepo: getFromLocalStorage('github-repo'),
+      taigaSlug: getFromLocalStorage('taiga-slug')
     };
   }
 
@@ -45,7 +47,9 @@ class Overview extends Component {
   render() {
     return (
       <div className="app-page">
-        <h2>Team Project Name</h2>
+        <h2>Overview: <p style={{color: colors.orange.base, display: 'inline'}}>
+            {this.state.ghRepo}</p> | <p style={{color:colors.green.base, display: 'inline'}}>
+            {this.state.taigaSlug}</p></h2>
         <ResponsiveReactGridLayout
           className="layout"
           cols={{ lg: 12, md: 10, sm: 6, xs: 4, xxs: 2 }}

--- a/taigit/src/components/ProjectPanel.js
+++ b/taigit/src/components/ProjectPanel.js
@@ -2,8 +2,10 @@ import React, { Component } from 'react';
 import {Link} from 'react-router-dom';
 import { getFromLocalStorage } from "../utils/utils";
 
-let projectList = getFromLocalStorage('project-list');
-//button onClick={this.props.delTodo.bind(this, id)}
+/**
+ * This component should only take in data from props
+ * It should also have an action
+ */
 export default class ProjectPanel extends Component {
     render() {
         return(

--- a/taigit/src/components/ProjectPanel.js
+++ b/taigit/src/components/ProjectPanel.js
@@ -1,27 +1,18 @@
 import React, { Component } from 'react';
 import {Link} from 'react-router-dom';
+import { getFromLocalStorage } from "../utils/utils";
 
+let projectList = getFromLocalStorage('project-list');
+//button onClick={this.props.delTodo.bind(this, id)}
 export default class ProjectPanel extends Component {
     render() {
         return(
             <div className="project">
-                <Link to={this.props.projUrl}>
-                    <p>{this.props.projName}</p>
-                </Link>
-                <div className="team-member-info">
-                    <Link to={this.props.memberUrl[0]}>
-                        <p>{this.props.member[0]}</p>
-                    </Link>
-                    <Link to={this.props.memberUrl[1]}>
-                        <p>{this.props.member[1]}</p>
-                    </Link>
-                    <Link to={this.props.memberUrl[2]}>
-                        <p>{this.props.member[2]}</p>
-                    </Link>
-                    <Link to={this.props.memberUrl[3]}>
-                        <p>{this.props.member[3]}</p>
-                    </Link>
-                </div>
+                { this.props.project }
+
+                <button>Analyze</button>
+
+                <button>x</button>
             </div>
         );
     }

--- a/taigit/src/components/Projects.js
+++ b/taigit/src/components/Projects.js
@@ -11,7 +11,8 @@ import {
     grabTaigaUserId,
     grabUserProjects,
     initializeUserData,
-    setTaigaProjectID
+    setTaigaProjectID,
+    loadAllTaigaProjectData,
 } from "../actions/taigaActions";
 import { getUsersRepos, addUserInfo } from "../actions/githubActions";
 import { saveToLocalStorage, getFromLocalStorage } from "../utils/utils";
@@ -51,15 +52,21 @@ class Projects extends Component {
   }
 
   componentWillMount() {
-    if (this.props.repoList || this.props.repoList.length == 0) {
+    // Only reload data if none exists
+    if (typeof this.props.repoList === 'undefined' || this.props.repoList.length == 0) {
       this.props.getUsersRepos(this.props.userLogin, auth);
     }
-    this.props.grabUserProjects(getFromLocalStorage('taiga-user-id'));
+    if (typeof this.props.projectList === 'undefined' || this.props.projectList.length == 0) {
+      this.props.grabUserProjects(getFromLocalStorage('taiga-user-id'));
+    }
   }
 
   onProjectAnalyze = (event) => {
       console.log('analyzing project!');
       event.preventDefault();
+
+      // Load all Taiga Data
+      this.props.loadAllTaigaProjectData(this.state.taigaProject.value);
 
       //save project set to be displayed in project panel
       //redirect to overview page
@@ -86,8 +93,6 @@ class Projects extends Component {
   }
   onTaigaSelectChange = (taigaProject) => {
     this.setState({ taigaProject });
-    saveToLocalStorage('taiga-slug', taigaProject.value);
-    this.props.setTaigaProjectID(taigaProject.value);
   }
 
   // Form change listeners
@@ -226,5 +231,6 @@ export default connect(mapStateToProps, {
     grabTaigaUserId,
     grabUserProjects,
     initializeUserData,
-    setTaigaProjectID
+    setTaigaProjectID,
+    loadAllTaigaProjectData
 })(Projects)

--- a/taigit/src/components/Projects.js
+++ b/taigit/src/components/Projects.js
@@ -1,125 +1,140 @@
 import React, { Component } from 'react';
-import {Link} from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import ProjectPanel from './ProjectPanel'
 import * as keys from '../keys.json';
 import { authRedirect, getAuthToken } from '../libraries/GitHub/GitHub';
 import Select from 'react-select';
 import colors from "../styles/colors";
-import {connect} from "react-redux";
+import { connect } from "react-redux";
 import { grabSprintStats } from "../actions/taigaActions";
 import { getUsersRepos } from "../actions/githubActions";
 import { saveToLocalStorage, getFromLocalStorage } from "../utils/utils";
 import { selectRepoList } from "../reducers";
-import GitHub from "./GitHub";
+import {
+  faGithub
+} from '@fortawesome/free-brands-svg-icons';
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 const redirect = authRedirect(keys.GH_CLIENT_ID);
 let storedProjects = getFromLocalStorage('project-list') || {};
 let auth = getFromLocalStorage('auth-key');
 
 class Projects extends Component {
-    state = {
-        githubID: '',
-        taigaID: '',
+  constructor(props) {
+    super(props);
+    this.state = {
+      githubID: '',
+      taigaID: '',
+      gitHubRepo: '',
+      taigaProject: ''
     }
 
-    onSubmit = (e) => {
-        e.preventDefault();
-        saveToLocalStorage('github-id', this.state.githubID);
-        saveToLocalStorage('taiga-id', this.state.taigaID);
-        this.props.getUsersRepos(this.state.githubID, auth);
-        e.target.reset();
+    this.handleTaigaChange = this.handleTaigaChange.bind(this);
+    this.onSubmit = this.onSubmit.bind(this);
+  }
+
+  onSubmit = (e) => {
+    e.preventDefault();
+    saveToLocalStorage('taiga-id', this.state.taigaID);
+    // call action to get list of all taiga projects
+    e.target.reset();
+  }
+
+  onGitHubSelectChange = (gitHubRepo) => {
+    this.setState({ gitHubRepo });
+  }
+
+  onTaigaSelectChange = (taigaProject) => {
+    this.setState({ taigaProject });
+  }
+
+  handleTaigaChange(event) {
+    this.setState({taigaID: event.target.value});
+  }
+
+  showProject = (proj) => (
+    storedProjects.map((proj) => (<ProjectPanel project={proj} />))
+  )
+
+  componentWillMount() {
+    if (this.props.repoList && this.props.repoList.length == 0) {
+      this.props.getUsersRepos(this.state.githubID, auth);
     }
+  }
 
-    onTextChange = (e) => {
-        this.setState({ [e.target.name]: e.target.value });
-    }
-
-    onSelectChange = (e) => {
-        this.setState({ githubOwner: e.target.value });
-        //this.setState({ githubRepo: e.target.label });
-        var str = this.state.githubID + ' || ' + this.state.taigaID;
-        console.log(storedProjects);
-        storedProjects.push(str);
-        saveToLocalStorage('project-list', storedProjects);
-        this.showProject(str);
-    }
-
-    onChange = (e) => {
-        this.setState({ [e.target.name]: e.target.value });
-        console.log(e.target.name);
-    }
-
-    showProject = (proj) => (
-        storedProjects.map((proj) => (<ProjectPanel project = {proj}/>))
-    )
-
-    componentWillMount() {
-        this.props.getUsersRepos(this.state.githubID, auth);
-    }
-
-    render() {
-        return(
-            <div className="app-page">
-                <h2>Projects</h2>
-                <h2>New Project</h2>
-                <div className="selector">
-                    <Select options={this.props.repoList}
-                            placeholder="Select GitHub Repository"
-                            onChange={this.onSelectChange}
-                            value={this.state.value}
-                            theme={(theme) => ({
-                                ...theme,
-                                colors: {
-                                    ...theme.colors,
-                                    primary25: colors.yellow.light,
-                                    primary: colors.blue.light,
-                                },
-                            })} />
-                </div>
-                <div className = "selector">
-                    <Select options={this.props.repoList}
-                            placeholder="Select Taiga Project"
-                            theme={(theme) => ({
-                                ...theme,
-                                colors: {
-                                    ...theme.colors,
-                                    primary25: colors.yellow.light,
-                                    primary: colors.blue.light,
-                                },
-                            })} />
-                </div>
-                <div className="form">
-                    <form onSubmit={this.onSubmit} style={{display: 'absolute'}}>
-                        <input type="text"
-                               name="githubID"
-                               style={{flex: '10', padding: '12px 20px', width: '20%', margin: '0 8px'}}
-                               placeholder="Your GitHub ID"
-                               value={this.state.title}
-                               onChange={this.onTextChange}
-                               id="text-form"
-                        />
-                        <input type="text"
-                               name="taigaID"
-                               style={{flex: '10', padding: '12px 20px', width: '20%', margin: '0 8px'}}
-                               placeholder="Your Taiga ID"
-                               value={this.state.title}
-                               onChange={this.onTextChange}
-                               id="text-form"
-                        />
-                        <input type="submit"
-                               value="Register Accounts"
-                               className="btn"
-                               style={{flex: '1', margin: '8px 4px', border: 'none'}}
-                        />
-                    </form>
-                </div>
-                <br/>
-                <a href={redirect}>
-                    <button type="button" className="gh-btn">Authenticate with GitHub</button>
-                </a>
+  render() {
+    return (
+      <div className="app-page">
+        <h2>Projects</h2>
+        {/* Render already paired projects here */}
+        <div className="project-picker">
+        <h3>New Project</h3>
+          <div className="project-selector-container">
+            <h4 className="project-selector-title">Select A Repo</h4>
+            <div className="selector project-selector">
+              <Select options={this.props.repoList}
+                placeholder="Select GitHub Repository"
+                onChange={this.onGitHubSelectChange}
+                value={this.state.githubRepo}
+                theme={(theme) => ({
+                    ...theme,
+                    colors: {
+                        ...theme.colors,
+                        primary25: colors.yellow.light,
+                        primary: colors.blue.light,
+                    },
+                })} 
+              />
             </div>
-        );
-    }
+          </div>
+          <div className="project-selector-container">
+            <h4 className="project-selector-title">Select A Project</h4>
+            <div className="selector project-selector">
+              <Select options={this.props.repoList}
+                placeholder="Select Taiga Project"
+                onChange={this.onTaigaSelectChange}
+                value={this.state.taigaProject}
+                theme={(theme) => ({
+                    ...theme,
+                    colors: {
+                        ...theme.colors,
+                        primary25: colors.yellow.light,
+                        primary: colors.blue.light,
+                    },
+                })} 
+              />
+            </div>
+          </div>
+          <button type="button" className="project-button">Analyze Project</button>
+        </div>
+        <h3>Connect Accounts</h3>
+        <div className="form">
+          <form onSubmit={this.onSubmit} style={{ display: 'absolute' }}>
+            <input type="text"
+              name="taigaID"
+              style={{ flex: '10', padding: '12px 20px', width: '20%', margin: '0 8px' }}
+              placeholder="Your Taiga ID"
+              value={this.state.taigaID}
+              onChange={this.handleTaigaChange}
+              id="text-form"
+            />
+            <input type="submit"
+              value="Connect Taiga Account"
+              className="btn"
+              style={{ flex: '1', margin: '8px 4px', border: 'none' }}
+            />
+          </form>
+        </div>
+        <br/>
+        <a href={redirect}>
+          <button type="button" className="gh-btn">
+            <FontAwesomeIcon className="navFont small-icon" icon={faGithub} size="2x"/>
+            Authenticate with GitHub
+          </button>
+        </a>
+      </div>
+    );
+  }
 }
 
 /**
@@ -128,7 +143,7 @@ class Projects extends Component {
  * to component props property (left)
  */
 const mapStateToProps = state => ({
-    repoList: selectRepoList(state)
+  repoList: selectRepoList(state)
 });
 
 export default connect(mapStateToProps, { grabSprintStats, getUsersRepos })(Projects)

--- a/taigit/src/components/Projects.js
+++ b/taigit/src/components/Projects.js
@@ -23,44 +23,53 @@ class Projects extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      githubID: '',
       taigaID: '',
+      taigaPassword: '',
       gitHubRepo: '',
       taigaProject: ''
     }
 
-    this.handleTaigaChange = this.handleTaigaChange.bind(this);
+    this.handleTaigaIDChange = this.handleTaigaIDChange.bind(this);
+    this.handleTaigaPasswordChange = this.handleTaigaPasswordChange.bind(this);
     this.onSubmit = this.onSubmit.bind(this);
   }
-
-  onSubmit = (e) => {
-    e.preventDefault();
-    saveToLocalStorage('taiga-id', this.state.taigaID);
-    // call action to get list of all taiga projects
-    e.target.reset();
-  }
-
-  onGitHubSelectChange = (gitHubRepo) => {
-    this.setState({ gitHubRepo });
-  }
-
-  onTaigaSelectChange = (taigaProject) => {
-    this.setState({ taigaProject });
-  }
-
-  handleTaigaChange(event) {
-    this.setState({taigaID: event.target.value});
-  }
-
-  showProject = (proj) => (
-    storedProjects.map((proj) => (<ProjectPanel project={proj} />))
-  )
 
   componentWillMount() {
     if (this.props.repoList && this.props.repoList.length == 0) {
       this.props.getUsersRepos(this.state.githubID, auth);
     }
   }
+
+  onSubmit = (e) => {
+    e.preventDefault();
+    saveToLocalStorage('taiga-id', this.state.taigaID);
+    /*** 
+     * call action which does the following:
+     * - login to taiga (store user id in redux)
+     * - get list of all projects (store in redux as well)
+    */
+    e.target.reset();
+  }
+
+  // Dropdown change listeners
+  onGitHubSelectChange = (gitHubRepo) => {
+    this.setState({ gitHubRepo });
+  }
+  onTaigaSelectChange = (taigaProject) => {
+    this.setState({ taigaProject });
+  }
+
+  // Form change listeners
+  handleTaigaIDChange(event) {
+    this.setState({taigaID: event.target.value});
+  }
+  handleTaigaPasswordChange(event) {
+    this.setState({taigaPassword: event.target.value});
+  }
+
+  showProject = (proj) => (
+    storedProjects.map((proj) => (<ProjectPanel project={proj} />))
+  )
 
   render() {
     return (
@@ -113,9 +122,17 @@ class Projects extends Component {
             <input type="text"
               name="taigaID"
               style={{ flex: '10', padding: '12px 20px', width: '20%', margin: '0 8px' }}
-              placeholder="Your Taiga ID"
+              placeholder="Your Taiga Username"
               value={this.state.taigaID}
-              onChange={this.handleTaigaChange}
+              onChange={this.handleTaigaIDChange}
+              id="text-form"
+            />
+            <input type="text"
+              name="taigaPassword"
+              style={{ flex: '10', padding: '12px 20px', width: '20%', margin: '0 8px' }}
+              placeholder="Your Taiga Password"
+              value={this.state.taigaPassword}
+              onChange={this.handleTaigaPasswordChange}
               id="text-form"
             />
             <input type="submit"

--- a/taigit/src/components/Projects.js
+++ b/taigit/src/components/Projects.js
@@ -7,13 +7,14 @@ import Select from 'react-select';
 import colors from "../styles/colors";
 import { connect } from "react-redux";
 import { grabSprintStats } from "../actions/taigaActions";
-import { getUsersRepos } from "../actions/githubActions";
+import { getUsersRepos, addUserInfo } from "../actions/githubActions";
 import { saveToLocalStorage, getFromLocalStorage } from "../utils/utils";
 import { selectRepoList } from "../reducers";
 import {
   faGithub
 } from '@fortawesome/free-brands-svg-icons';
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { selectUserLogin } from '../reducers';
 
 const redirect = authRedirect(keys.GH_CLIENT_ID);
 let storedProjects = getFromLocalStorage('project-list') || {};
@@ -35,9 +36,10 @@ class Projects extends Component {
   }
 
   componentWillMount() {
-    if (this.props.repoList && this.props.repoList.length == 0) {
+    if (this.props.repoList || this.props.repoList.length == 0) {
       this.props.getUsersRepos(this.state.githubID, auth);
     }
+    this.props.addUserInfo(auth);
   }
 
   onSubmit = (e) => {
@@ -160,7 +162,8 @@ class Projects extends Component {
  * to component props property (left)
  */
 const mapStateToProps = state => ({
-  repoList: selectRepoList(state)
+  repoList: selectRepoList(state),
+  userLogin: selectUserLogin(state)
 });
 
-export default connect(mapStateToProps, { grabSprintStats, getUsersRepos })(Projects)
+export default connect(mapStateToProps, { grabSprintStats, getUsersRepos, addUserInfo })(Projects)

--- a/taigit/src/components/Projects.js
+++ b/taigit/src/components/Projects.js
@@ -7,33 +7,38 @@ import Select from 'react-select';
 import colors from "../styles/colors";
 import {connect} from "react-redux";
 import { grabSprintStats } from "../actions/taigaActions";
+import { getUsersRepos } from "../actions/githubActions";
 import { saveToLocalStorage, getFromLocalStorage } from "../utils/utils";
-//import { selectRepoList } from '../reducers';
+import { selectRepoList } from "../reducers";
+import GitHub from "./GitHub";
 
 const redirect = authRedirect(keys.GH_CLIENT_ID);
-let storedProjects = getFromLocalStorage('project-list') || [];
-saveToLocalStorage();
+let storedProjects = getFromLocalStorage('project-list') || {};
+let auth = getFromLocalStorage('auth-key');
 
 class Projects extends Component {
     state = {
         githubID: '',
         taigaID: '',
-    }
+        githubOwner: '',
+        githubRepo: ''
+    };
 
     onSubmit = (e) => {
         e.preventDefault();
         saveToLocalStorage('github-id', this.state.githubID);
         saveToLocalStorage('taiga-id', this.state.taigaID);
-        var str = this.state.githubID + ' || ' + this.state.taigaID;
-        console.log(storedProjects);
-        storedProjects.push(str);
-        saveToLocalStorage('project-list', storedProjects);
-        this.showProject(str);
+        this.props.getUsersRepos(this.state.githubID, auth);
+        e.target.reset();
     }
 
-    onChange = (e) => {
+    onTextChange = (e) => {
         this.setState({ [e.target.name]: e.target.value });
-        console.log(e.target.name);
+    }
+
+    onSelectChange = (e) => {
+        this.setState({ githubOwner: e.target.value });
+        //this.setState({ githubRepo: e.target.label });
     }
 
     showProject = (proj) => (
@@ -41,7 +46,7 @@ class Projects extends Component {
     )
 
     componentWillMount() {
-        //this.props.grabRepoList();
+        this.props.getUsersRepos(this.state.githubID, auth);
     }
 
     render() {
@@ -50,7 +55,22 @@ class Projects extends Component {
                 <h2>Projects</h2>
                 <h2>New Project</h2>
                 <div className="selector">
-                    <Select options={this.props.sprintList}
+                    <Select options={this.props.repoList}
+                            placeholder="Select GitHub Repository"
+                            onChange={this.onSelectChange}
+                            value={this.state.value}
+                            theme={(theme) => ({
+                                ...theme,
+                                colors: {
+                                    ...theme.colors,
+                                    primary25: colors.yellow.light,
+                                    primary: colors.blue.light,
+                                },
+                            })} />
+                </div>
+                <div className = "selector">
+                    <Select options={this.props.repoList}
+                            placeholder="Select Taiga Project"
                             theme={(theme) => ({
                                 ...theme,
                                 colors: {
@@ -67,14 +87,16 @@ class Projects extends Component {
                                style={{flex: '10', padding: '12px 20px', width: '20%', margin: '0 8px'}}
                                placeholder="Your GitHub ID"
                                value={this.state.title}
-                               onChange={this.onChange}
+                               onChange={this.onTextChange}
+                               id="text-form"
                         />
                         <input type="text"
                                name="taigaID"
                                style={{flex: '10', padding: '12px 20px', width: '20%', margin: '0 8px'}}
                                placeholder="Your Taiga ID"
                                value={this.state.title}
-                               onChange={this.onChange}
+                               onChange={this.onTextChange}
+                               id="text-form"
                         />
                         <input type="submit"
                                value="Register Accounts"
@@ -98,7 +120,7 @@ class Projects extends Component {
  * to component props property (left)
  */
 const mapStateToProps = state => ({
-    //repos: selectRepoList(state),
+    repoList: selectRepoList(state)
 });
 
-export default connect(mapStateToProps, { grabSprintStats })(Projects)
+export default connect(mapStateToProps, { grabSprintStats, getUsersRepos })(Projects)

--- a/taigit/src/components/Projects.js
+++ b/taigit/src/components/Projects.js
@@ -56,6 +56,10 @@ class Projects extends Component {
   }
 
   componentWillMount() {
+    this.setState({repoOwner: getFromLocalStorage('github-owner')});
+    this.setState({repoName: getFromLocalStorage('github-repo') || ''});
+    this.setState({taigaProjectSlug: getFromLocalStorage('taiga-slug')});
+
     // Only reload data if none exists
     if (typeof this.props.repoList === 'undefined' || this.props.repoList.length == 0) {
       this.props.getUsersRepos(this.props.userLogin, auth);
@@ -132,7 +136,7 @@ class Projects extends Component {
             <h4 className="project-selector-title">Select A Repo</h4>
             <div className="selector project-selector">
               <Select options={this.props.repoList}
-                placeholder="Select GitHub Repository"
+                placeholder={this.state.repoName == '' ? "Select GitHub Repository" : this.state.repoName}
                 onChange={this.onGitHubSelectChange}
                 theme={(theme) => ({
                     ...theme,
@@ -149,7 +153,7 @@ class Projects extends Component {
             <h4 className="project-selector-title">Select A Project</h4>
             <div className="selector project-selector">
               <Select options={this.props.projectList}
-                placeholder="Select Taiga Project"
+                placeholder={this.state.taigaProjectSlug == '' ? "Select Taiga Project" : this.state.taigaProjectSlug}
                 onChange={this.onTaigaSelectChange}
                 theme={(theme) => ({
                     ...theme,

--- a/taigit/src/components/Projects.js
+++ b/taigit/src/components/Projects.js
@@ -14,7 +14,10 @@ import {
     setTaigaProjectID,
     loadAllTaigaProjectData,
 } from "../actions/taigaActions";
-import { getUsersRepos, addUserInfo } from "../actions/githubActions";
+import { 
+  getUsersRepos, 
+  addUserInfo,
+  loadAllGitHubProjectData } from "../actions/githubActions";
 import { saveToLocalStorage, getFromLocalStorage } from "../utils/utils";
 import {
     selectRepoList,
@@ -37,8 +40,9 @@ class Projects extends Component {
     this.state = {
       taigaID: '',
       taigaPassword: '',
-      gitHubRepo: '',
-      taigaProject: '',
+      repoOwner: '',
+      repoName: '',
+      taigaProjectSlug: '',
       taigaNumID: '',
       codacyID: ''
     }
@@ -62,14 +66,21 @@ class Projects extends Component {
   }
 
   onProjectAnalyze = (event) => {
-      console.log('analyzing project!');
-      event.preventDefault();
+    console.log('analyzing project!');
+    event.preventDefault();
 
-      // Load all Taiga Data
-      this.props.loadAllTaigaProjectData(this.state.taigaProject.value);
+    // Save necessary data (in case of refresh)
+    saveToLocalStorage('github-owner', this.state.repoOwner);
+    saveToLocalStorage('github-repo', this.state.repoName);
+    saveToLocalStorage('taiga-slug', this.state.taigaProjectSlug);
 
-      //save project set to be displayed in project panel
-      //redirect to overview page
+    // Load all Taiga Data
+    this.props.loadAllTaigaProjectData(this.state.taigaProjectSlug);
+
+    // Load all GitHub Data
+    this.props.loadAllGitHubProjectData(this.state.repoOwner, 
+      this.state.repoName, 
+      auth);
   }
 
   onTaigaSubmit = (e) => {
@@ -79,20 +90,19 @@ class Projects extends Component {
     e.target.reset();
   }
 
-    onCodacySubmit = (e) => {
-        e.preventDefault();
+  onCodacySubmit = (e) => {
+    e.preventDefault();
 
-        e.target.reset();
-    }
+    e.target.reset();
+  }
 
   // Dropdown change listeners
   onGitHubSelectChange = (gitHubRepo) => {
-    this.setState({ gitHubRepo });
-    saveToLocalStorage('github-owner', gitHubRepo.value);
-    saveToLocalStorage('github-repo', gitHubRepo.label);
+    this.setState({ repoOwner: gitHubRepo.value });
+    this.setState({ repoName: gitHubRepo.label})
   }
   onTaigaSelectChange = (taigaProject) => {
-    this.setState({ taigaProject });
+    this.setState({ taigaProjectSlug: taigaProject.value });
   }
 
   // Form change listeners
@@ -232,5 +242,6 @@ export default connect(mapStateToProps, {
     grabUserProjects,
     initializeUserData,
     setTaigaProjectID,
-    loadAllTaigaProjectData
+    loadAllTaigaProjectData,
+    loadAllGitHubProjectData
 })(Projects)

--- a/taigit/src/components/Projects.js
+++ b/taigit/src/components/Projects.js
@@ -3,50 +3,102 @@ import {Link} from 'react-router-dom';
 import ProjectPanel from './ProjectPanel'
 import * as keys from '../keys.json';
 import { authRedirect, getAuthToken } from '../libraries/GitHub/GitHub';
+import Select from 'react-select';
+import colors from "../styles/colors";
+import {connect} from "react-redux";
+import { grabSprintStats } from "../actions/taigaActions";
+import { saveToLocalStorage, getFromLocalStorage } from "../utils/utils";
+//import { selectRepoList } from '../reducers';
 
 const redirect = authRedirect(keys.GH_CLIENT_ID);
+let storedProjects = getFromLocalStorage('project-list') || [];
+saveToLocalStorage();
 
-export default class Projects extends Component {
+class Projects extends Component {
+    state = {
+        githubID: '',
+        taigaID: '',
+    }
+
+    onSubmit = (e) => {
+        e.preventDefault();
+        saveToLocalStorage('github-id', this.state.githubID);
+        saveToLocalStorage('taiga-id', this.state.taigaID);
+        var str = this.state.githubID + ' || ' + this.state.taigaID;
+        console.log(storedProjects);
+        storedProjects.push(str);
+        saveToLocalStorage('project-list', storedProjects);
+        this.showProject(str);
+    }
+
+    onChange = (e) => {
+        this.setState({ [e.target.name]: e.target.value });
+        console.log(e.target.name);
+    }
+
+    showProject = (proj) => (
+        storedProjects.map((proj) => (<ProjectPanel project = {proj}/>))
+    )
+
+    componentWillMount() {
+        //this.props.grabRepoList();
+    }
+
     render() {
         return(
             <div className="app-page">
                 <h2>Projects</h2>
-                <ProjectPanel projUrl="/"
-                              projName="Team Broccoli"
-                              memberUrl={["/team/members/broutzong","","",""]}
-                              member={["Bailey Routzong", "Amy Koffee","Miguel Smith","Mr Wicked"]}
-                />
-                <br/>
                 <h2>New Project</h2>
+                <div className="selector">
+                    <Select options={this.props.sprintList}
+                            theme={(theme) => ({
+                                ...theme,
+                                colors: {
+                                    ...theme.colors,
+                                    primary25: colors.yellow.light,
+                                    primary: colors.blue.light,
+                                },
+                            })} />
+                </div>
                 <div className="form">
-                    <form style={{display: 'absolute'}}>
+                    <form onSubmit={this.onSubmit} style={{display: 'absolute'}}>
                         <input type="text"
-                               name="repo-name"
+                               name="githubID"
                                style={{flex: '10', padding: '12px 20px', width: '20%', margin: '0 8px'}}
-                               placeholder="GitHub repository name"
+                               placeholder="Your GitHub ID"
+                               value={this.state.title}
+                               onChange={this.onChange}
                         />
                         <input type="text"
-                               name="repo-owner"
+                               name="taigaID"
                                style={{flex: '10', padding: '12px 20px', width: '20%', margin: '0 8px'}}
-                               placeholder="GitHub repository owner"
-                        />
-                        <input type="text"
-                               name="taiga"
-                               style={{flex: '10', padding: '12px 20px', width: '20%', margin: '0 8px'}}
-                               placeholder="Taiga project ID"
+                               placeholder="Your Taiga ID"
+                               value={this.state.title}
+                               onChange={this.onChange}
                         />
                         <input type="submit"
-                               value="Add Project"
+                               value="Register Accounts"
                                className="btn"
                                style={{flex: '1', margin: '8px 4px', border: 'none'}}
                         />
                     </form>
                 </div>
-                <br/><br/>
+                <br/>
                 <a href={redirect}>
-                    <button type="button" className="gh-btn">Sign in to GitHub</button>
+                    <button type="button" className="gh-btn">Authenticate with GitHub</button>
                 </a>
             </div>
         );
     }
 }
+
+/**
+ * mapStateToProps
+ * maps state in redux store (right)
+ * to component props property (left)
+ */
+const mapStateToProps = state => ({
+    //repos: selectRepoList(state),
+});
+
+export default connect(mapStateToProps, { grabSprintStats })(Projects)

--- a/taigit/src/components/Taiga.js
+++ b/taigit/src/components/Taiga.js
@@ -5,7 +5,8 @@ import { connect } from 'react-redux';
 import { Doughnut, Bar, Line } from 'react-chartjs-2';
 import { 
   grabSprintStats, 
-  grabSingleSprintData 
+  grabSingleSprintData,
+  loadAllTaigaProjectData 
 } from '../actions/taigaActions';
 import {
   selectSprintList,
@@ -47,8 +48,10 @@ class Taiga extends Component {
   }
 
   componentWillMount() {
-    this.props.grabSprintStats(220659);
-    this.props.grabSingleSprintData(220752, this.props.projectData.id,'Sprint 2 - Taiga');
+    // Handle if user refreshes on taiga page
+    if (Object.keys(this.props.projectData).length == 0) {
+      this.props.loadAllTaigaProjectData(this.state.taigaSlug);
+    }
     originalLayouts = getLayoutFromLocalStorage(layoutname, 'layouts') || [];
     this.setState({ layouts: JSON.parse(JSON.stringify(originalLayouts)) });
   }
@@ -181,5 +184,9 @@ const mapStateToProps = state => ({
  * connect(mapStateToProps, actions)(componentName)
  * connects the component to the redux store
  */
-export default connect(mapStateToProps, { grabSprintStats, grabSingleSprintData })(Taiga)
+export default connect(mapStateToProps, { 
+  grabSprintStats, 
+  grabSingleSprintData, 
+  loadAllTaigaProjectData 
+})(Taiga)
 

--- a/taigit/src/components/Taiga.js
+++ b/taigit/src/components/Taiga.js
@@ -4,14 +4,15 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Doughnut, Bar, Line } from 'react-chartjs-2';
 import { 
-  grabTaigaData, grabSprintStats, 
-  grabSprintNames, grabSingleSprintData 
+  grabSprintStats, 
+  grabSingleSprintData 
 } from '../actions/taigaActions';
 import {
   selectSprintList,
   selectSprintProgressChartData,
   selectSprintBurndownChartData,
-  selectSingleSprintData
+  selectSingleSprintData,
+  selectTaigaProjectData
 } from '../reducers';
 import {saveLayoutToLocalStorage, getLayoutFromLocalStorage, getFromLocalStorage} from '../utils/utils';
 import { WidthProvider, Responsive } from "react-grid-layout";
@@ -46,10 +47,8 @@ class Taiga extends Component {
   }
 
   componentWillMount() {
-    this.props.grabTaigaData(this.state.taigaSlug);
-    this.props.grabSprintNames(this.state.taigaProjectID);
     this.props.grabSprintStats(220659);
-    this.props.grabSingleSprintData(220752, this.state.taigaProjectID,'Sprint 2 - Taiga');
+    this.props.grabSingleSprintData(220752, this.props.projectData.id,'Sprint 2 - Taiga');
     originalLayouts = getLayoutFromLocalStorage(layoutname, 'layouts') || [];
     this.setState({ layouts: JSON.parse(JSON.stringify(originalLayouts)) });
   }
@@ -57,7 +56,7 @@ class Taiga extends Component {
   render() {
     return(
       <div className="app-page">
-        <h2>Taiga: <p style={{color: colors.red.base, display: 'inline'}}>{this.state.taigaSlug}</p></h2>
+        <h2>Taiga: <p style={{color: colors.red.base, display: 'inline'}}>{this.props.projectData.name}</p></h2>
         <div className="selector">
           <Select options={this.props.sprintList}
           theme={(theme) => ({
@@ -96,7 +95,6 @@ class Taiga extends Component {
               <Bar data={this.props.singleSprintData} options={barGraphOptions}/>
             </div>
           </div>
-          <h4>{this.props.storeData}</h4>
         </ResponsiveReactGridLayout>
       </div>
     );
@@ -166,22 +164,13 @@ const burndownOptions = {
       }
     }
 
-
-/**
- * Declaring the types for all props that Taiga component uses
- */
-Taiga.propTypes = {
-  grabTaigaData: PropTypes.func.isRequired,
-  data: PropTypes.string
-}
-
 /**
  * mapStateToProps
  * maps state in redux store (right)
  * to component props property (left)
  */
 const mapStateToProps = state => ({
-  storeData: state.taiga.taigaData,
+  projectData: selectTaigaProjectData(state),
   sprintProgress: selectSprintProgressChartData(state),
   sprintList: selectSprintList(state),
   burnDownData: selectSprintBurndownChartData(state),
@@ -192,5 +181,5 @@ const mapStateToProps = state => ({
  * connect(mapStateToProps, actions)(componentName)
  * connects the component to the redux store
  */
-export default connect(mapStateToProps, { grabTaigaData, grabSprintStats, grabSprintNames, grabSingleSprintData })(Taiga)
+export default connect(mapStateToProps, { grabSprintStats, grabSingleSprintData })(Taiga)
 

--- a/taigit/src/components/Taiga.js
+++ b/taigit/src/components/Taiga.js
@@ -13,7 +13,7 @@ import {
   selectSprintBurndownChartData,
   selectSingleSprintData
 } from '../reducers';
-import { saveLayoutToLocalStorage, getLayoutFromLocalStorage } from '../utils/utils';
+import {saveLayoutToLocalStorage, getLayoutFromLocalStorage, getFromLocalStorage} from '../utils/utils';
 import { WidthProvider, Responsive } from "react-grid-layout";
 import colors from '../styles/colors';
 
@@ -26,7 +26,9 @@ class Taiga extends Component {
     super(props);
 
     this.state = {
-      layouts: JSON.parse(JSON.stringify(originalLayouts))
+      layouts: JSON.parse(JSON.stringify(originalLayouts)),
+      taigaProjectID: getFromLocalStorage('taiga-project-id'),
+      taigaSlug: getFromLocalStorage('taiga-slug')
     };
   }
 
@@ -44,10 +46,10 @@ class Taiga extends Component {
   }
 
   componentWillMount() {
-    this.props.grabTaigaData('sanaydevi-ser-574');
-    this.props.grabSprintNames(306316);
-    this.props.grabSprintStats();
-    this.props.grabSingleSprintData(220752, 306316,'Sprint 2 - Taiga');
+    this.props.grabTaigaData(this.state.taigaSlug);
+    this.props.grabSprintNames(this.state.taigaProjectID);
+    this.props.grabSprintStats(220659);
+    this.props.grabSingleSprintData(220752, this.state.taigaProjectID,'Sprint 2 - Taiga');
     originalLayouts = getLayoutFromLocalStorage(layoutname, 'layouts') || [];
     this.setState({ layouts: JSON.parse(JSON.stringify(originalLayouts)) });
   }
@@ -55,7 +57,7 @@ class Taiga extends Component {
   render() {
     return(
       <div className="app-page">
-        <h2>Taiga</h2>
+        <h2>Taiga: <p style={{color: colors.red.base, display: 'inline'}}>{this.state.taigaSlug}</p></h2>
         <div className="selector">
           <Select options={this.props.sprintList}
           theme={(theme) => ({

--- a/taigit/src/components/Team.js
+++ b/taigit/src/components/Team.js
@@ -21,7 +21,7 @@ class Team extends Component {
   render() {
     return(
       <div className="app-page">
-        <h2>TeamName</h2>
+        <h2>Team</h2>
           <div className="team-members">
           {this.props.teamMembers.map((memberObj) => {
             return <div className="team-member-page-card"> 

--- a/taigit/src/components/Team.js
+++ b/taigit/src/components/Team.js
@@ -10,11 +10,19 @@ import {
 import { selectBasicContributorData } from '../reducers';
 
 class Team extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      githubOwner: getFromLocalStorage('github-owner') || '',
+      githubRepo: getFromLocalStorage('github-repo') || ''
+    };
+  }
+
   componentWillMount() {
-    let auth = getFromLocalStorage('auth-key');
-    console.log('auth key is', auth);
     if (this.props.teamMembers.length == 0) {
-      this.props.getContributorData('ser574-green-team', 'taigit', auth);
+      let auth = getFromLocalStorage('auth-key');
+      this.props.getContributorData(this.state.githubOwner, this.state.githubRepo, auth);
     }
   }
 

--- a/taigit/src/libraries/GitHub/GitHub.js
+++ b/taigit/src/libraries/GitHub/GitHub.js
@@ -9,6 +9,7 @@ export {contributorData} from "./src/contributorData";
 export {authRedirect, getAuthToken} from "./src/auth"
 export {getContributerNames} from "./src/getUserList";
 export {getMcCabeComplexity} from "./src/cyclomaticComplexity";
+export {getUserRepos} from './src/reposAvailable';
 export {usesMaven, usesGradle, usesCMake, usesMake, usesAnt, getBuilds} from "./src/findBuilds"
 export {getMemberInfo} from "./src/getMemberInfo"
 export {gethistoryPR} from "./src/getHistoryOfPR"

--- a/taigit/src/libraries/GitHub/GitHub.js
+++ b/taigit/src/libraries/GitHub/GitHub.js
@@ -11,6 +11,7 @@ export {getContributerNames} from "./src/getUserList";
 export {getMcCabeComplexity} from "./src/cyclomaticComplexity";
 export {getUserRepos} from './src/reposAvailable';
 export {usesMaven, usesGradle, usesCMake, usesMake, usesAnt, getBuilds} from "./src/findBuilds"
-export {getMemberInfo} from "./src/getMemberInfo"
-export {gethistoryPR} from "./src/getHistoryOfPR"
+export {getMemberInfo} from "./src/getMemberInfo";
+export {gethistoryPR} from "./src/getHistoryOfPR";
+export {getUserInfo} from './src/getUserInfo';
 

--- a/taigit/src/libraries/GitHub/src/getUserInfo.ts
+++ b/taigit/src/libraries/GitHub/src/getUserInfo.ts
@@ -1,0 +1,18 @@
+import axios from "axios";
+/**
+ * The following function grabs user info when given the auth key
+ */
+export async function
+getUserInfo(auth: string){
+    try{
+        var config = {
+            headers: {'Authorization': "Bearer " + auth}
+        }
+        let userInfo = await axios.get("https://api.github.com/user", config);
+        return userInfo.data;
+    }
+    catch (error) {
+        console.log(error)
+        return -1
+    }
+}

--- a/taigit/src/libraries/GitHub/src/reposAvailable.ts
+++ b/taigit/src/libraries/GitHub/src/reposAvailable.ts
@@ -6,7 +6,7 @@ getUserRepos(owner: string, auth: string){
         var config = {
             headers: {'Authorization': "Bearer " + auth}
         }
-        const userRepos = await axios.get("https://api.github.com/users/" + owner +
+        const userRepos = await axios.get("https://api.github.com/user/repos", config);
             "/repos", config);
         return userRepos.data;
     } catch (error) {

--- a/taigit/src/libraries/GitHub/src/reposAvailable.ts
+++ b/taigit/src/libraries/GitHub/src/reposAvailable.ts
@@ -1,0 +1,16 @@
+import axios from 'axios';
+
+export async function
+getUserRepos(owner: string, auth: string){
+    try{
+        var config = {
+            headers: {'Authorization': "Bearer " + auth}
+        }
+        const userRepos = await axios.get("https://api.github.com/users/" + owner +
+            "/repos", config);
+        return userRepos.data;
+    } catch (error) {
+        console.log(error);
+    }
+    return -1;
+}

--- a/taigit/src/libraries/GitHub/src/reposAvailable.ts
+++ b/taigit/src/libraries/GitHub/src/reposAvailable.ts
@@ -6,8 +6,7 @@ getUserRepos(owner: string, auth: string){
         var config = {
             headers: {'Authorization': "Bearer " + auth}
         }
-        const userRepos = await axios.get("https://api.github.com/user/repos", config);
-            "/repos", config);
+        const userRepos = await axios.get("https://api.github.com/user/repos?per_page=1000", config);
         return userRepos.data;
     } catch (error) {
         console.log(error);

--- a/taigit/src/reducers/githubReducer.js
+++ b/taigit/src/reducers/githubReducer.js
@@ -7,7 +7,8 @@ import { GET_BRANCH_LIST,
   ADD_AUTH_KEY, 
   GET_PULL_REQUESTS_CLOSED,
   GET_AVG_COMMENTS_PR,
-  ADD_USER_REPOS
+  ADD_USER_REPOS,
+  ADD_USER_INFO
 } from '../actions/githubActions';
 
 const initialState = {
@@ -19,7 +20,8 @@ const initialState = {
   authKey: '',
   numPullRequestsClosed: 0,
   avgCommentsOnPR : 0,
-  userRepos: []
+  userRepos: [],
+  user: {}
 }
 /**
  * Github Reducer
@@ -78,6 +80,12 @@ const githubReducer = (state = {}, action) => {
       return {
         ...state,
         userRepos: action.payload
+      }
+    case ADD_USER_INFO:
+      console.log('user info: ', action.payload);
+      return {
+        ...state,
+        user: action.payload
       }
     default:
       return {
@@ -169,6 +177,10 @@ export const selectRepoList = (state) => {
       label: repo.name
     }
   });
+}
+
+export const selectUserLogin = (state) => {
+  return state.user && state.user.login;
 }
 
 export default githubReducer

--- a/taigit/src/reducers/githubReducer.js
+++ b/taigit/src/reducers/githubReducer.js
@@ -165,7 +165,7 @@ export const selectAvgCommentsPRData = (state) => {
 export const selectRepoList = (state) => {
   return state.userRepos.map(repo => {
     return {
-      value: repo.owner,
+      value: repo.full_name,
       label: repo.name
     }
   });

--- a/taigit/src/reducers/githubReducer.js
+++ b/taigit/src/reducers/githubReducer.js
@@ -162,4 +162,13 @@ export const selectAvgCommentsPRData = (state) => {
   return state.avgCommentsOnPR;
 }
 
+export const selectRepoList = (state) => {
+  return state.userRepos.map(repo => {
+    return {
+      value: repo.owner,
+      label: repo.name
+    }
+  });
+}
+
 export default githubReducer

--- a/taigit/src/reducers/githubReducer.js
+++ b/taigit/src/reducers/githubReducer.js
@@ -6,7 +6,8 @@ import { GET_BRANCH_LIST,
   GET_NUM_BRANCH_COMMITS, 
   ADD_AUTH_KEY, 
   GET_PULL_REQUESTS_CLOSED,
-  GET_AVG_COMMENTS_PR 
+  GET_AVG_COMMENTS_PR,
+  ADD_USER_REPOS
 } from '../actions/githubActions';
 
 const initialState = {
@@ -17,7 +18,8 @@ const initialState = {
   numBranchCommits: [],
   authKey: '',
   numPullRequestsClosed: 0,
-  avgCommentsOnPR : 0
+  avgCommentsOnPR : 0,
+  userRepos: []
 }
 /**
  * Github Reducer
@@ -71,6 +73,12 @@ const githubReducer = (state = {}, action) => {
           ...state,
           avgCommentsOnPR: action.payload
       } 
+    case ADD_USER_REPOS:
+      console.log('payload for user repos is: ', action.payload);
+      return {
+        ...state,
+        userRepos: action.payload
+      }
     default:
       return {
         ...initialState,

--- a/taigit/src/reducers/githubReducer.js
+++ b/taigit/src/reducers/githubReducer.js
@@ -173,7 +173,7 @@ export const selectAvgCommentsPRData = (state) => {
 export const selectRepoList = (state) => {
   return state.userRepos.map(repo => {
     return {
-      value: repo.full_name,
+      value: repo.owner,
       label: repo.name
     }
   });

--- a/taigit/src/reducers/index.js
+++ b/taigit/src/reducers/index.js
@@ -26,3 +26,4 @@ export const selectRepoList = (state) => fromGithub.selectRepoList(state.github)
 export const selectUserLogin = (state) => fromGithub.selectUserLogin(state.github);
 export const selectTaigaUserID = (state) => fromTaiga.selectTaigaUserID(state.taiga);
 export const selectProjectList = (state) => fromTaiga.selectProjectList(state.taiga);
+export const selectTaigaProjectData = (state) => fromTaiga.selectTaigaProjectData(state.taiga);

--- a/taigit/src/reducers/index.js
+++ b/taigit/src/reducers/index.js
@@ -23,3 +23,4 @@ export const selectSingleSprintData = (state) => fromTaiga.selectSingleSprintDat
 export const selectAvgCommentsPRData  = (state) => fromGithub.selectAvgCommentsPRData (state.github);
 export const selectBasicContributorData = (state) => fromTeam.selectBasicContributorData(state.team);
 export const selectRepoList = (state) => fromGithub.selectRepoList(state.github);
+export const selectUserLogin = (state) => fromGithub.selectUserLogin(state.github);

--- a/taigit/src/reducers/index.js
+++ b/taigit/src/reducers/index.js
@@ -24,3 +24,5 @@ export const selectAvgCommentsPRData  = (state) => fromGithub.selectAvgCommentsP
 export const selectBasicContributorData = (state) => fromTeam.selectBasicContributorData(state.team);
 export const selectRepoList = (state) => fromGithub.selectRepoList(state.github);
 export const selectUserLogin = (state) => fromGithub.selectUserLogin(state.github);
+export const selectTaigaUserID = (state) => fromTaiga.selectTaigaUserID(state.taiga);
+export const selectProjectList = (state) => fromTaiga.selectProjectList(state.taiga);

--- a/taigit/src/reducers/index.js
+++ b/taigit/src/reducers/index.js
@@ -22,3 +22,4 @@ export const selectNumPullRequestsClosedData = (state) => fromGithub.selectNumPu
 export const selectSingleSprintData = (state) => fromTaiga.selectSingleSprintData(state.taiga);
 export const selectAvgCommentsPRData  = (state) => fromGithub.selectAvgCommentsPRData (state.github);
 export const selectBasicContributorData = (state) => fromTeam.selectBasicContributorData(state.team);
+export const selectRepoList = (state) => fromGithub.selectRepoList(state.github);

--- a/taigit/src/reducers/taigaReducer.js
+++ b/taigit/src/reducers/taigaReducer.js
@@ -1,13 +1,15 @@
 import { 
-  GRAB_TAIGA_DATA, GET_SPRINT_STATS, 
-  GET_TASK_STATS, GET_SPRINT_NAMES, 
+  GRAB_TAIGA_DATA,
+  GET_SPRINT_STATS,
+  GET_TASK_STATS,
+  GET_SPRINT_NAMES,
   GET_SINGLE_SPRINT_STATS,
-  TAIGA_LOGIN, GET_USER_PROJECTS
-}from '../actions/taigaActions';
+  TAIGA_LOGIN,
+  GET_USER_PROJECTS
+} from '../actions/taigaActions';
 import colors from '../styles/colors';
 
 const initialState = {
-  taigaData: 'initialData',
   sprintList: [],
   sprintStats: {},
   taigaTaskStats: [],
@@ -24,50 +26,38 @@ const initialState = {
  */
 export default function taigaReducer(state = initialState, action) {
   switch(action.type) {
-    case GRAB_TAIGA_DATA: 
-      console.log('in reducer of grab taiga data');
-      console.log('payload is: ', action.payload);
-      console.log('returning state', { ...state, taigaData: action.payload });
-      
+    case GRAB_TAIGA_DATA:       
       // Return new object of current state spread and new property (taigaData)
       return {
         ...state,
         taigaProjectData: action.payload
       }
     case GET_SPRINT_STATS:
-      console.log('got sprint stats');
-      console.log('stats: ', action.payload);
       return {
         ...state,
         sprintStats: action.payload
       }
     case GET_TASK_STATS:
-      //console.log('in Task details reducer');
       return {
         ...state,
         taigaTaskStats: action.payload
       }
     case GET_SINGLE_SPRINT_STATS:
-      console.log('got sprint stats');
-      console.log('singleSprintStats: ', action.payload);
       return {
         ...state,
         singleSprintStats: action.payload
       }
     case GET_SPRINT_NAMES:
-      console.log("Get sprint name");
       return {
         ...state,
         sprintList: action.payload
       }
     case TAIGA_LOGIN:
-      console.log("Getting Taiga login info", action.payload);
       return {
         ...state,
         userId: action.payload
       }
     case GET_USER_PROJECTS:
-      console.log("Getting user projects:", action.payload);
       return {
         ...state,
         projectList: action.payload
@@ -76,6 +66,10 @@ export default function taigaReducer(state = initialState, action) {
       return state;
   }
 }
+
+/**
+ * Selectors - interface between component props and redux state
+ */
 
 /**
  * Getting current sprint task progress
@@ -192,6 +186,13 @@ export const selectSprintBurndownChartData = (state) => {
           borderColor: [colors.blue.base]
         }]
   }
+}
+
+/**
+ * Selects project data from state
+ */
+export const selectTaigaProjectData = (state) => {
+  return state.taigaProjectData;
 }
 
 /**

--- a/taigit/src/reducers/taigaReducer.js
+++ b/taigit/src/reducers/taigaReducer.js
@@ -10,6 +10,7 @@ import {
 import colors from '../styles/colors';
 
 const initialState = {
+  taigaProjectData: {},
   sprintList: [],
   sprintStats: {},
   taigaTaskStats: [],

--- a/taigit/src/reducers/taigaReducer.js
+++ b/taigit/src/reducers/taigaReducer.js
@@ -1,7 +1,8 @@
 import { 
   GRAB_TAIGA_DATA, GET_SPRINT_STATS, 
   GET_TASK_STATS, GET_SPRINT_NAMES, 
-  GET_SINGLE_SPRINT_STATS 
+  GET_SINGLE_SPRINT_STATS,
+  TAIGA_LOGIN, GET_USER_PROJECTS
 }from '../actions/taigaActions';
 import colors from '../styles/colors';
 
@@ -11,6 +12,8 @@ const initialState = {
   sprintStats: {},
   taigaTaskStats: [],
   singleSprintStats: [],
+  userId: {},
+  projectList: []
 }
 
 /**
@@ -56,6 +59,18 @@ export default function taigaReducer(state = initialState, action) {
       return {
         ...state,
         sprintList: action.payload
+      }
+    case TAIGA_LOGIN:
+      console.log("Getting Taiga login info", action.payload);
+      return {
+        ...state,
+        userId: action.payload
+      }
+    case GET_USER_PROJECTS:
+      console.log("Getting user projects:", action.payload);
+      return {
+        ...state,
+        projectList: action.payload
       }
     default:
       return state;
@@ -253,5 +268,18 @@ export const selectSingleSprintData = (state) => {
       data: readyForTestTaskCount
     }]
   }
+}
 
+export const selectTaigaUserID = (state) => {
+  console.log("user id is ",state.userId.id);
+  return state.userId.id;
+}
+
+export const selectProjectList = (state) => {
+  return state.projectList.map(project => {
+    return {
+      value: project,
+      label: project
+    }
+  });
 }

--- a/taigit/src/styles/Projects.scss
+++ b/taigit/src/styles/Projects.scss
@@ -35,7 +35,7 @@
 .gh-btn {
   background-color: #08708A;
   color: white;
-  padding: 14px 25px;
+  padding: 1.2em 2.2em;
   text-align: center;
   position: relative;
   left: 40%;
@@ -44,4 +44,31 @@
 .gh-btn:hover {
   background-color: #56B1BF;
   cursor: pointer;
+}
+
+.small-icon {
+  margin-right: 0.25em;
+}
+
+.project-button {
+  background-color: #08708A;
+  color: white;
+  padding: 1.2em 2.2em;
+  text-align: center;
+}
+
+.project-selector-container {
+  display: inline-block;
+}
+
+.project-selector-title {
+  display: inline-block;
+  margin: 0px auto;
+  margin-right: 0.5em;
+  color: grey;
+}
+
+.project-selector {
+  display: inline-block;
+  margin-right: 1em;
 }

--- a/taigit/src/styles/Projects.scss
+++ b/taigit/src/styles/Projects.scss
@@ -38,7 +38,7 @@
   padding: 1.2em 2.2em;
   text-align: center;
   position: relative;
-  left: 40%;
+  left: 8px;
 }
 
 .gh-btn:hover {


### PR DESCRIPTION
Project selection is now possible! On the Projects page, you can authenticate with Github, connect with Taiga, and then select projects to display using the dropdown buttons. The project selection is now hooked up to the components on the GitHub and Taiga page, so you should be able to change which projects you want to look at and the graphs will change to match.

To test:
1. Open the Project page and click Authenticate with Github and follow the instructions.
2. Back on the Project page, add your Taiga username and password, then press "Connect Taiga Account".
3. Ignore the Codacy input button. That's not working yet. Congrats, you've now connected your accounts to our app!
4. Use the two dropdown menus to select which Github and Taiga projects you want to look at. You can press the Analyze Project button, but it won't do anything. Your project is actually being set when you make the selection in the dropdown.
5. Switch to the other tabs. GitHub and Taiga pages should show the right data if those components were already connected to the API. I refactored most components, but there are still some with dummy data.
6. The titles of each page should now show the names of the project.
7. Try changing the projects in the selectors and see if everything shows up correctly.
8. Profit.

Sometimes things don't show up right away, so try refreshing the page if something isn't appearing. If you have components in other branches that are still using hardcoded data, let me know and I can help you pull in the right data for your function calls.